### PR TITLE
Allow custom fonts to be provided in the JSON.

### DIFF
--- a/utils/amp-page-head.snip.html
+++ b/utils/amp-page-head.snip.html
@@ -26,6 +26,10 @@ limitations under the License.
 
   {{> amp-extension-script.snip.html}}
 
+  {{#font-stylesheets}}
+    <link href="{{{.}}}" rel="stylesheet">
+  {{/font-stylesheets}}
+
   <link href="dist/css/{{{css-path}}}" rel="stylesheet" amp-custom>
 
   <script async src="https://cdn.ampproject.org/v0.js"></script>


### PR DESCRIPTION
This change allows custom font stylesheets to be provided in the JSON data like this:

      "font-stylesheets": [
        "https://fonts.googleapis.com/css?family=Playfair+Display%7CLora%7CLato"
      ]

For reference: https://www.ampproject.org/docs/guides/responsive/custom_fonts

If there’s better way to conditionally include partial templates that doesn’t involve using a list, please let me know!