### PR TITLE
Add CSS page var for body background color.

### DIFF
--- a/css/ampstart-base/base-page-vars.css
+++ b/css/ampstart-base/base-page-vars.css
@@ -27,6 +27,8 @@
   --color-grey: #6e6e6e;
   --color-black: #000;
 
+  --color-body-background: #fff;
+
   --color-primary: #000;
   --color-font-primary: #fff;
 

--- a/css/ampstart-base/base-page.css
+++ b/css/ampstart-base/base-page.css
@@ -21,6 +21,7 @@
 
 /* Body */
 body {
+  background: var(--color-body-background);
   color: var(--color-font-default);
   line-height: var(--line-height-3);
   font-family: var(--font-family);


### PR DESCRIPTION
Explicitly set to white by default, but can be easily customised in page-vars.css