### PR TITLE
Add support for text-based logos in the navbar.

### DIFF
--- a/components/navbar/navbar.snip.html
+++ b/components/navbar/navbar.snip.html
@@ -28,7 +28,7 @@ limitations under the License.
         <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="fixed" class="my0 mx-auto {{classes}}" alt="{{name}}"></amp-img>
       {{/url}}
       {{^url}}
-        <h1 class="h3 bold caps mx-auto {{classes}}">{{name}}</h1>
+        <div class="h3 bold caps mx-auto {{classes}}">{{name}}</div>
       {{/url}}
       {{#href}}
       </a>

--- a/components/navbar/navbar.snip.html
+++ b/components/navbar/navbar.snip.html
@@ -22,12 +22,17 @@ limitations under the License.
     <div role="button" on="tap:{{sidebar-id}}.toggle" tabindex="0" class="ampstart-navbar-trigger {{^sidebaronly}}md-hide lg-hide{{/sidebaronly}} pr2">☰</div>
     {{#logo}}
       {{#href}}
-      <a href="{{.}}" class="text-decoration-none inline-block">
+      <a href="{{.}}" class="text-decoration-none inline-block mx-auto">
       {{/href}}
-      <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="fixed" class="my0 mx-auto {{classes}}" alt="{{name}}"></amp-img>
+      {{#url}}
+        <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="fixed" class="my0 mx-auto {{classes}}" alt="{{name}}"></amp-img>
+      {{/url}}
+      {{^url}}
+        <h1 class="h3 bold caps mx-auto {{classes}}">{{name}}</h1>
+      {{/url}}
       {{#href}}
-      {{/href}}
       </a>
+      {{/href}}
     {{/logo}}
     {{^sidebaronly}}
       <nav class="ampstart-headerbar-nav ampstart-nav xs-hide sm-hide">


### PR DESCRIPTION
Render the `amp-img` element only when the logo `url` has been provided, otherwise render an `h1` containing the site name instead. The default class names I’ve applied to the `h1` are what I need for the opinionated theme 2 template, but I could pass them in the `classes` variable instead.

Let me know what you think.