### PR TITLE
Fix <link rel=canonical> tag.

### DIFF
--- a/templates/article.amp.json
+++ b/templates/article.amp.json
@@ -2,6 +2,7 @@
   "article": {
     "head-tag": {
       "title": "The Photo Blog",
+      "canonical-path": "templates/article.amp",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",

--- a/templates/blog.amp.json
+++ b/templates/blog.amp.json
@@ -2,6 +2,7 @@
   "blog": {
     "head-tag": {
       "title": "The Recipe Blog",
+      "canonical-path": "templates/blog.amp",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",

--- a/templates/test-all.amp.json
+++ b/templates/test-all.amp.json
@@ -2,6 +2,7 @@
   "test-all-amp": {
     "head-tag": {
       "title": "Test Page",
+      "canonical-path": "templates/test-all.amp",
       "extensions": [
         "amp-accordion",
         "amp-form"

--- a/templates/themes/2/home.amp.json
+++ b/templates/themes/2/home.amp.json
@@ -2,6 +2,7 @@
   "home": {
     "head-tag": {
       "title": "Beck & Galo",
+      "canonical-path": "templates/themes/2/home.amp",
       "extensions": [
         "amp-carousel",
         "amp-image-lightbox",

--- a/templates/themes/2/menu.amp.json
+++ b/templates/themes/2/menu.amp.json
@@ -2,6 +2,7 @@
   "menu": {
     "head-tag": {
       "title": "Beck & Galo – Menu",
+      "canonical-path": "templates/themes/2/menu.amp",
       "extensions": [
         "amp-sidebar"
       ],

--- a/templates/thescenic.amp.json
+++ b/templates/thescenic.amp.json
@@ -2,6 +2,7 @@
   "thescenic": {
     "head-tag": {
       "title": "The Photo Blog",
+      "canonical-path": "templates/thescenic.amp",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",

--- a/utils/amp-page-head.snip.html
+++ b/utils/amp-page-head.snip.html
@@ -20,7 +20,7 @@ limitations under the License.
 <head>
   <meta charset="utf-8">
   <title>{{title}}</title>
-  <link rel="canonical" href="www.ampstart.com" >
+  <link rel="canonical" href="https://www.ampstart.com/{{#canonical-path}}{{{canonical-path}}}{{/canonical-path}}">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
   {{> amp-boilerplate-css.snip.html}}
 

--- a/www/components.json
+++ b/www/components.json
@@ -2,6 +2,7 @@
   "www-components": {
     "head-tag": {
       "title": "AMPStart - UI Components",
+      "canonical-path": "components",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",

--- a/www/getstarted.json
+++ b/www/getstarted.json
@@ -2,6 +2,7 @@
   "www-getstarted": {
     "head-tag": {
       "title": "AMPStart - Get Started",
+      "canonical-path": "getstarted",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",

--- a/www/howitworks.json
+++ b/www/howitworks.json
@@ -2,6 +2,7 @@
   "www-howitworks": {
     "head-tag": {
       "title": "AMPStart - How it works",
+      "canonical-path": "howitworks",
       "extensions": [
         "amp-sidebar",
         "amp-analytics"

--- a/www/index.json
+++ b/www/index.json
@@ -2,6 +2,7 @@
   "www-index": {
     "head-tag": {
       "title": "AMPStart",
+      "canonical-path": "",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",


### PR DESCRIPTION
As per issue #138.

I assume hardcoding `https://www.ampstart.com/` is okay here?

Note that this doesn’t fix the `<link rel=canonical>` tag for the `render/` pages since some of those seem to share data.json files, but this is hopefully a step in the right direction.