### PR TITLE
Don’t escape @href, @src, @action or @action-xhr attribute values.

### DIFF
--- a/components/byline/byline.snip.html
+++ b/components/byline/byline.snip.html
@@ -19,10 +19,10 @@ limitations under the License.
   <!-- Start byline -->
   <address class="ampstart-byline clearfix mb4 px3 h5">
     {{#image}}
-    <amp-img class="ampstart-byline-photo mr3 left" src="{{.}}" layout="fixed" height="60" width="60"></amp-img>
+    <amp-img class="ampstart-byline-photo mr3 left" src="{{{.}}}" layout="fixed" height="60" width="60"></amp-img>
     {{/image}}
     {{#author}}
-    <a class="ampstart-byline-author block text-decoration-none my1" href="{{url}}" role="author">{{text}}</a>
+    <a class="ampstart-byline-author block text-decoration-none my1" href="{{{url}}}" role="author">{{text}}</a>
     {{/author}}
     {{#time}}
     <time class="ampstart-byline-pubdate block bold my1" datetime="{{value}}">{{text}}</time>

--- a/components/dropdown/dropdown-inline.snip.html
+++ b/components/dropdown/dropdown-inline.snip.html
@@ -22,7 +22,7 @@ limitations under the License.
     <header>{{heading}}</header>
     <ul class="ampstart-dropdown-items list-reset m0 p0">
       {{#options}}
-        <li class="ampstart-dropdown-item"><a href="{{link.url}}" class="text-decoration-none">{{link.text}}</a></li>
+        <li class="ampstart-dropdown-item"><a href="{{{link.url}}}" class="text-decoration-none">{{link.text}}</a></li>
       {{/options}}
     </ul>
   </section>

--- a/components/dropdown/dropdown.snip.html
+++ b/components/dropdown/dropdown.snip.html
@@ -23,7 +23,7 @@ limitations under the License.
     <header>{{heading}}</header>
     <ul class="ampstart-dropdown-items list-reset m0 p0">
       {{#options}}
-        <li class="ampstart-dropdown-item"><a href="{{link.url}}" class="text-decoration-none">{{link.text}}</a></li>
+        <li class="ampstart-dropdown-item"><a href="{{{link.url}}}" class="text-decoration-none">{{link.text}}</a></li>
       {{/options}}
     </ul>
   </section>

--- a/components/footer/footer.snip.html
+++ b/components/footer/footer.snip.html
@@ -24,7 +24,7 @@ limitations under the License.
       <nav class="ampstart-footer-nav">
         <ul class="list-reset flex flex-wrap mb3">
           {{#links}}
-            <li class="px1"><a class="text-decoration-none caps h5" href="{{url}}">{{text}}</a></li>
+            <li class="px1"><a class="text-decoration-none caps h5" href="{{{url}}}">{{text}}</a></li>
           {{/links}}
         </ul>
       </nav>

--- a/components/form/form.snip.html
+++ b/components/form/form.snip.html
@@ -17,7 +17,7 @@ limitations under the License.
 }}
 
 {{#form}}
-<form method="{{method}}" {{#action}}action="{{.}}"{{/action}}{{#action-xhr}}action-xhr="{{.}}"{{/action-xhr}} target="_top" {{novalidate}} class="p0 m0 px3 mb4">
+<form method="{{method}}" {{#action}}action="{{{.}}}"{{/action}}{{#action-xhr}}action-xhr="{{{.}}}"{{/action-xhr}} target="_top" {{novalidate}} class="p0 m0 px3 mb4">
   <fieldset class="border-none p0 m0">
     {{#title}}
     <legend class="h2 block mb4">{{.}}</legend>

--- a/components/images/fullpage-hero.snip.html
+++ b/components/images/fullpage-hero.snip.html
@@ -19,8 +19,8 @@ limitations under the License.
 {{#fullpage-hero}}
   <!-- Start Fullpage Hero -->
   <figure class="ampstart-image-fullpage-hero m0 relative mb4">
-    <amp-img width="404" height="720" layout="responsive" src="{{narrow-img}}" media="(max-width: 415px)"></amp-img>
-    <amp-img height="720" layout="fixed-height" src="{{wide-img}}" media="(min-width: 416px)"></amp-img>
+    <amp-img width="404" height="720" layout="responsive" src="{{{narrow-img}}}" media="(max-width: 415px)"></amp-img>
+    <amp-img height="720" layout="fixed-height" src="{{{wide-img}}}" media="(min-width: 416px)"></amp-img>
     <figcaption class="absolute top-0 right-0 bottom-0 left-0">
       <header class="p3">
         <h1 class="ampstart-fullpage-hero-heading mb3">
@@ -31,7 +31,7 @@ limitations under the License.
 
         {{#credit}}
           <span class="ampstart-image-credit h4">
-            {{credit-prefix}} {{#author}}<a href="{{url}}" role="author" class="text-decoration-none">{{text}}</a>{{/author}}{{#credit-suffix}},<br> {{.}}{{/credit-suffix}}
+            {{credit-prefix}} {{#author}}<a href="{{{url}}}" role="author" class="text-decoration-none">{{text}}</a>{{/author}}{{#credit-suffix}},<br> {{.}}{{/credit-suffix}}
           </span>
         {{/credit}}
     </header>

--- a/components/images/images.snip.html
+++ b/components/images/images.snip.html
@@ -19,7 +19,7 @@ limitations under the License.
 {{#image-with-heading}}
   <!-- Start Image with heading -->
   <figure class="ampstart-image-with-heading  m0 relative mb4">
-    <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="responsive"></amp-img>
+    <amp-img src="{{{url}}}" width="{{width}}" height="{{height}}" layout="responsive"></amp-img>
     <figcaption class="absolute right-0 bottom-0 left-0">
       <header class="ampstart-image-heading px2 py2 line-height-4">{{{heading-html}}}</header>
     </figcaption>
@@ -30,14 +30,14 @@ limitations under the License.
 {{#image-with-caption}}
   <!-- Start Image with Caption -->
   <figure class="ampstart-image-with-caption m0 relative mb4">
-    <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="responsive" class=""></amp-img>
+    <amp-img src="{{{url}}}" width="{{width}}" height="{{height}}" layout="responsive" class=""></amp-img>
     <figcaption class="h5 mt1 px3">
       {{caption}}
       {{#credit}}
         <span class="ampstart-image-credit block bold">
           {{credit-prefix}}
           {{#author}}
-            <a href="{{url}}" role="author">{{text}}</a>
+            <a href="{{{url}}}" role="author">{{text}}</a>
           {{/author}}
         </span>
       {{/credit}}

--- a/components/lightbox/template-preview.snip.html
+++ b/components/lightbox/template-preview.snip.html
@@ -23,7 +23,7 @@ limitations under the License.
   <div class="ampstart-device-preview-mask absolute top-0 right-0 left-0 bottom-0 {{classes}}" role="button" on="tap:{{lightbox-id}}.close" tabindex="0"></div>
   <amp-selector>
     <div class="ampstart-device-preview-select flex justify-around items-center center absolute top-0 left-0 right-0">
-      <button class="ampstart-btn"><a href="{{download}}" class="h4 text-decoration-none block" target="_blank">DOWNLOAD CODE</a></button>
+      <button class="ampstart-btn"><a href="{{{download}}}" class="h4 text-decoration-none block" target="_blank">DOWNLOAD CODE</a></button>
       <h3>Article Template Preview</h3>
       <div>
         <amp-img src="img/www/mobile.png" width="18" height="35" layout="fixed" alt="mobile icon" option="mobile" selected class="xs-hide"></amp-img>
@@ -37,7 +37,7 @@ limitations under the License.
                sandbox="allow-scripts allow-popups"
                allowfullscreen
                frameborder="0"
-               src="{{src}}" class="absolute xs-hide">
+               src="{{{src}}}" class="absolute xs-hide">
                <div placeholder></div>
           </amp-iframe>
         </div>
@@ -53,7 +53,7 @@ limitations under the License.
                sandbox="allow-scripts allow-popups"
                allowfullscreen
                frameborder="0"
-               src="{{src}}"  class="absolute xs-hide">
+               src="{{{src}}}"  class="absolute xs-hide">
                <div placeholder></div>
           </amp-iframe>
         </div>
@@ -67,7 +67,7 @@ limitations under the License.
              sandbox="allow-scripts allow-popups"
              allowfullscreen
              frameborder="0"
-             src="{{src}}" class="absolute top-0 left-0 right-0 bottom-0">
+             src="{{{src}}}" class="absolute top-0 left-0 right-0 bottom-0">
              <div placeholder></div>
         </amp-iframe>
       </div>

--- a/components/navbar/navbar.snip.html
+++ b/components/navbar/navbar.snip.html
@@ -22,10 +22,10 @@ limitations under the License.
     <div role="button" on="tap:{{sidebar-id}}.toggle" tabindex="0" class="ampstart-navbar-trigger {{^sidebaronly}}md-hide lg-hide{{/sidebaronly}} pr2">☰</div>
     {{#logo}}
       {{#href}}
-      <a href="{{.}}" class="text-decoration-none inline-block mx-auto">
+      <a href="{{{.}}}" class="text-decoration-none inline-block mx-auto">
       {{/href}}
       {{#url}}
-        <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="fixed" class="my0 mx-auto {{classes}}" alt="{{name}}"></amp-img>
+        <amp-img src="{{{url}}}" width="{{width}}" height="{{height}}" layout="fixed" class="my0 mx-auto {{classes}}" alt="{{name}}"></amp-img>
       {{/url}}
       {{^url}}
         <div class="h3 bold caps mx-auto {{classes}}">{{name}}</div>
@@ -39,7 +39,7 @@ limitations under the License.
         <ul class="list-reset center m0 p0 flex justify-center nowrap">
           {{#nav}}
             {{#link}}
-              <li class="ampstart-nav-item {{classes}}"><a href="{{url}}" class="text-decoration-none block" {{#target}}target="{{.}}"{{/target}}>{{text}}</a></li>
+              <li class="ampstart-nav-item {{classes}}"><a href="{{{url}}}" class="text-decoration-none block" {{#target}}target="{{.}}"{{/target}}>{{text}}</a></li>
             {{/link}}
             {{#dropdown}}
               <li class="ampstart-nav-item ampstart-nav-dropdown relative">

--- a/components/navbar/sidebar.snip.html
+++ b/components/navbar/sidebar.snip.html
@@ -25,7 +25,7 @@ limitations under the License.
     <ul class="list-reset m0 p0 caps h5">
       {{#nav}}
         {{#link}}
-          <li class="ampstart-nav-item"><a href="{{url}}">{{text}}</a></li>
+          <li class="ampstart-nav-item"><a href="{{{url}}}">{{text}}</a></li>
         {{/link}}
         {{#dropdown}}
           <li class="ampstart-nav-item ampstart-nav-dropdown relative">
@@ -46,7 +46,7 @@ limitations under the License.
   {{#faq}}
     <ul class="ampstart-sidebar-faq list-reset m0">
       {{#links}}
-        <li class="ampstart-faq-item"><a href="{{link.url}}" class="text-decoration-none">{{link.text}}</a></li>
+        <li class="ampstart-faq-item"><a href="{{{link.url}}}" class="text-decoration-none">{{link.text}}</a></li>
       {{/links}}
     </ul>
   {{/faq}}

--- a/components/related-article/related-article.snip.html
+++ b/components/related-article/related-article.snip.html
@@ -28,7 +28,7 @@ limitations under the License.
   {{/section-heading}}
   <article class="ampstart-related-article">
     {{#hero-img}}
-      <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="responsive" alt="" class="mb3"></amp-img>
+      <amp-img src="{{{url}}}" width="{{width}}" height="{{height}}" layout="responsive" alt="" class="mb3"></amp-img>
     {{/hero-img}}
     {{#article-heading}}
       {{#level}}
@@ -44,7 +44,7 @@ limitations under the License.
       </p>
     {{/content-text}}
     {{#article-link}}
-      <a href="{{url}}" class="ampstart-rekated-article-readmore block text-decoration-none caps h5">{{text}}</a>
+      <a href="{{{url}}}" class="ampstart-rekated-article-readmore block text-decoration-none caps h5">{{text}}</a>
     {{/article-link}}
   </article>
 </section>

--- a/components/social-follow/social-follow.snip.html
+++ b/components/social-follow/social-follow.snip.html
@@ -22,31 +22,31 @@ limitations under the License.
   {{#links}}
     <li class="mr2">
       {{#twitter}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/twitter.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/twitter.svg}}</a>
       {{/twitter}}
       {{#facebook}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/facebook.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/facebook.svg}}</a>
       {{/facebook}}
       {{#instagram}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/instagram.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/instagram.svg}}</a>
       {{/instagram}}
       {{#pinterest}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/pinterest.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/pinterest.svg}}</a>
       {{/pinterest}}
       {{#email}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/email.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/email.svg}}</a>
       {{/email}}
       {{#gplus}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/gplus.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/gplus.svg}}</a>
       {{/gplus}}
       {{#github}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/github.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/github.svg}}</a>
       {{/github}}
       {{#wordpress}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/wordpress.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/wordpress.svg}}</a>
       {{/wordpress}}
       {{#slack}}
-        <a href="{{.}}" class="inline-block">{{> ../../img/icons/slack.svg}}</a>
+        <a href="{{{.}}}" class="inline-block">{{> ../../img/icons/slack.svg}}</a>
       {{/slack}}
     </li>
   {{/links}}

--- a/hl-partials/navbar-sidebar-only.html
+++ b/hl-partials/navbar-sidebar-only.html
@@ -1,7 +1,7 @@
 <!-- Start Navbar -->
 <header class="ampstart-headerbar fixed flex justify-start items-center top-0 left-0 right-0 pl2 pr4">
     <div role="button" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger  pr2">☰</div>
-    <amp-img src="..&#x2F;img&#x2F;thescenic&#x2F;header-logo.png" width="110" height="33" layout="fixed" class="my0 mx-auto " alt="The Blog"></amp-img>
+    <amp-img src="../img/thescenic/header-logo.png" width="110" height="33" layout="fixed" class="my0 mx-auto " alt="The Blog"></amp-img>
 </header>
 
 <!-- Start Sidebar -->

--- a/hl-partials/navbar-with-sidebar.html
+++ b/hl-partials/navbar-with-sidebar.html
@@ -1,7 +1,7 @@
 <!-- Start Navbar -->
 <header class="ampstart-headerbar fixed flex justify-start items-center top-0 left-0 right-0 pl2 pr4">
   <div role="button" on="tap:header-sidebar.toggle" tabindex="0" class="ampstart-navbar-trigger md-hide lg-hide pr2">☰</div>
-  <amp-img src="..&#x2F;img&#x2F;thescenic&#x2F;header-logo.png" width="110" height="33" layout="fixed" class="my0 mx-auto " alt="The Blog"></amp-img>
+  <amp-img src="../img/thescenic/header-logo.png" width="110" height="33" layout="fixed" class="my0 mx-auto " alt="The Blog"></amp-img>
   <nav class="ampstart-headerbar-nav ampstart-nav xs-hide sm-hide">
     <ul class="list-reset center m0 p0 flex justify-center nowrap">
       <li class="ampstart-nav-item ampstart-nav-dropdown relative">

--- a/templates/themes/2/home.amp.html
+++ b/templates/themes/2/home.amp.html
@@ -24,14 +24,14 @@ limitations under the License.
 
   {{#fullpage-hero}}
     <figure class="ampstart-image-fullpage-hero m0 relative mb4">
-      <amp-img width="404" height="720" layout="responsive" src="{{narrow-img}}" media="(max-width: 415px)"></amp-img>
-      <amp-img height="720" layout="fixed-height" src="{{wide-img}}" media="(min-width: 416px)"></amp-img>
+      <amp-img width="404" height="720" layout="responsive" src="{{{narrow-img}}}" media="(max-width: 415px)"></amp-img>
+      <amp-img height="720" layout="fixed-height" src="{{{wide-img}}}" media="(min-width: 416px)"></amp-img>
       <header class="absolute top-0 right-0 left-0 center">
         {{{heading-html}}}
       </header>
       {{#cta}}
         <div class="absolute right-0 bottom-0 left-0 center">
-          <a class="h5 px4 py3 m3 inline-block text-decoration-none border" href="{{url}}">{{text}}</a>
+          <a class="h5 px4 py3 m3 inline-block text-decoration-none border" href="{{{url}}}">{{text}}</a>
         </div>
       {{/cta}}
     </figure>
@@ -58,7 +58,7 @@ limitations under the License.
             <amp-image-lightbox id="lightbox" layout="nodisplay"></amp-image-lightbox>
             <amp-carousel class="my2 mxn3" height="{{height}}" layout="fixed-height" type="carousel">
               {{#images}}
-                <amp-img src="{{url}}" width="{{width}}" height="{{height}}" alt="{{alt}}" on="tap:lightbox" role="button" tabindex="0"></amp-img>
+                <amp-img src="{{{url}}}" width="{{width}}" height="{{height}}" alt="{{alt}}" on="tap:lightbox" role="button" tabindex="0"></amp-img>
               {{/images}}
             </amp-carousel>
           {{/carousel}}

--- a/templates/themes/2/menu.amp.html
+++ b/templates/themes/2/menu.amp.html
@@ -31,7 +31,7 @@ limitations under the License.
             {{#pick}}
               <dt class="h5 mb2 block regular">{{heading}}</dt>
               {{#image}}
-                <dd class="m0"><amp-img class="mb2" src="{{url}}" width="{{width}}" height="{{height}}" alt="{{alt}}" layout="responsive"></amp-img></dd>
+                <dd class="m0"><amp-img class="mb2" src="{{{url}}}" width="{{width}}" height="{{height}}" alt="{{alt}}" layout="responsive"></amp-img></dd>
               {{/image}}
               <dt class="col col-10 h2 mb1">{{dish}}</dt>
               <dd class="col col-2 m0 mb1 self-center right-align">{{price}}</dd>

--- a/www/components.html
+++ b/www/components.html
@@ -53,7 +53,7 @@ limitations under the License.
             {{#render.iframe}}
             <!-- Rendered Output -->
             <div class="www-component-iframe-container">
-              <amp-iframe src="{{url}}" height="{{height}}" layout="{{layout}}" {{#width}}width="{{.}}"{{/width}} sandbox="allow-scripts" class="www-component-rendered {{#card}}ampstart-card{{/card}} mb2 center">
+              <amp-iframe src="{{{url}}}" height="{{height}}" layout="{{layout}}" {{#width}}width="{{.}}"{{/width}} sandbox="allow-scripts" class="www-component-rendered {{#card}}ampstart-card{{/card}} mb2 center">
                 <div placeholder></div>
               </amp-iframe>
             </div>

--- a/www/index.html
+++ b/www/index.html
@@ -56,16 +56,16 @@ limitations under the License.
         {{#template-preview}}
         <li class="relative clearfix mb2">
           {{#img}}
-          <amp-img src="{{url}}" width="{{width}}" height="{{height}}" layout="{{layout}}" class="ampstart-card xs-col-12 sm-col-5 md-col-4 lg-col-3 mx4 {{#right-aligned}}col-right{{/right-aligned}}{{^right-aligned}}left col {{/right-aligned}}"></amp-img>
+          <amp-img src="{{{url}}}" width="{{width}}" height="{{height}}" layout="{{layout}}" class="ampstart-card xs-col-12 sm-col-5 md-col-4 lg-col-3 mx4 {{#right-aligned}}col-right{{/right-aligned}}{{^right-aligned}}left col {{/right-aligned}}"></amp-img>
           {{/img}}
           <div class="px4 mt4">
           <h3 class="caps py4">{{title}}</h3>
           <p class="pb4">{{desc}}</p>
           <div class="pb2 center">
             <button class="ampstart-btn caps xs-hide mr2 mb2" on="tap:{{lightbox-id}}">View Template</button>
-            <button class="ampstart-btn caps xs-hide mr2 mb2"><a href="{{download}}" class="text-decoration-none block" target="_blank">Download Code</a></button>
+            <button class="ampstart-btn caps xs-hide mr2 mb2"><a href="{{{download}}}" class="text-decoration-none block" target="_blank">Download Code</a></button>
 
-            <button class="ampstart-btn caps sm-hide md-hide lg-hide"><a href="{{src}}" target="_blank" class="block text-decoration-none">View Template</a></button>
+            <button class="ampstart-btn caps sm-hide md-hide lg-hide"><a href="{{{src}}}" target="_blank" class="block text-decoration-none">View Template</a></button>
           </div>
           </div>
         </li>


### PR DESCRIPTION
This gets rid of the `&#x2F;` characters from paths throughout the site, as reported in #168.