### PR TITLE
Don’t encode the favicon path.

### DIFF
--- a/utils/amp-page-head.snip.html
+++ b/utils/amp-page-head.snip.html
@@ -24,7 +24,7 @@ limitations under the License.
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
 
   {{#favicon}}
-  <link rel="shortcut icon" href="{{href}}">
+  <link rel="shortcut icon" href="{{{href}}}">
   {{/favicon}}
 
   {{> amp-boilerplate-css.snip.html}}


### PR DESCRIPTION
This will fix #216.