### PR TITLE
Fix Theme 1 jump link position

### DIFF
--- a/css/ampstart-base/base-page.css
+++ b/css/ampstart-base/base-page.css
@@ -51,3 +51,8 @@ p {
 .ampstart-accent {
   color: var(--color-font-accent);
 }
+
+#content {
+  margin-top: calc(0px - var(--navbar-height));
+  padding-top: var(--navbar-height);
+}

--- a/css/templates/themes/1/page.css
+++ b/css/templates/themes/1/page.css
@@ -51,6 +51,11 @@ h4,
   line-height: var(--line-height-2);
 }
 
+#content {
+  padding-top: var(--space-6);
+  margin-top: calc(0px - var(--space-6));
+}
+
 .ampstart-headerbar {
   background: var(--color-primary);
   color: var(--color-font-primary);
@@ -104,6 +109,10 @@ h4,
 .ampstart-fullpage-hero-heading {
   font-size: var(--h2);
   line-height: 1.6;
+  margin-bottom: 0;
+}
+
+.ampstart-image-fullpage-hero {
   margin-bottom: 0;
 }
 

--- a/css/templates/themes/1/page.css
+++ b/css/templates/themes/1/page.css
@@ -51,11 +51,6 @@ h4,
   line-height: var(--line-height-2);
 }
 
-#content {
-  padding-top: var(--space-6);
-  margin-top: calc(0px - var(--space-6));
-}
-
 .ampstart-headerbar {
   background: var(--color-primary);
   color: var(--color-font-primary);


### PR DESCRIPTION
Uses `--navbar-height` to offset jump-link in base to allow consistency when filtered through to opinionated templates.