### PR TITLE
Suggestion: make repo self-sufficient by using npm script aliases to the gulp tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ AMP Start is built on top of [Basscss](http://basscss.com/) a low-level CSS tool
 
 1. Install [NodeJS](https://nodejs.org).
 2. In the repo directory, run `npm i` command to install the required npm packages.
-3. Run `npm i -g gulp` command to install gulp system-wide (on Mac or Linux you may need to prefix this with `sudo`, depending on how Node was installed).
 
 ### Build & Test
 | Command                                                                 | Description                                                           |

--- a/README.md
+++ b/README.md
@@ -15,12 +15,12 @@ AMP Start is built on top of [Basscss](http://basscss.com/) a low-level CSS tool
 ### Build & Test
 | Command                                                                 | Description                                                           |
 | ----------------------------------------------------------------------- | --------------------------------------------------------------------- |
-| `gulp build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
-| `gulp clean`                                                            | Removes build output.                                                 |
-| `gulp www`                                                              | Recompile www to build directory.                                     |
-| `gulp highlight`                                                        | Build HTML for code highlighting.                                     |
-| `gulp watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
-| `gulp serve`                                                            | Serves content in repo root dir over http://localhost:8000/.|
+| `npm run build`<sup>[[1]](#footnote-1)</sup>                               | Builds the AMP library.                                               |
+| `npm run clean`                                                            | Removes build output.                                                 |
+| `npm run www`                                                              | Recompile www to build directory.                                     |
+| `npm run highlight`                                                        | Build HTML for code highlighting.                                     |
+| `npm run watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
+| `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/.|
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 

--- a/package.json
+++ b/package.json
@@ -1,13 +1,13 @@
 {
   "name": "kickstart",
-	"script": {
-		"build": "gulp build",
-		"clean": "gulp clean",
-		"www": "gulp www",
-		"highlight": "gulp highlight",
-		"watch": "gulp watch",
-		"serve": "gulp serve"
-	},
+  "script": {
+    "build": "gulp build",
+    "clean": "gulp clean",
+    "www": "gulp www",
+    "highlight": "gulp highlight",
+    "watch": "gulp watch",
+    "serve": "gulp serve"
+  },
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,13 @@
 {
   "name": "kickstart",
+	"script": {
+		"build": "gulp build",
+		"clean": "gulp clean",
+		"www": "gulp www",
+		"highlight": "gulp highlight",
+		"watch": "gulp watch",
+		"serve": "gulp serve"
+	},
   "private": true,
   "license": "Apache-2.0",
   "devDependencies": {


### PR DESCRIPTION
This pull request aliases the gulp tasks mentioned in the readme to npm scripts calls. 
This makes the project independent from a global gulp install. 
Global installs as a dependency to a project can cause unnecessary problems when developers have to have incompatible versions globally installed or just don't want to install deps globally. 
Luckily nowadays it is absolutely not necessary to globally install any task runner because we have `npm scripts`.

I did not consult anybody before doing this, but since it is just a small change I thought I'll send it as a quick PR. Please just dismiss if you don't like this suggestion.