### PR TITLE
replace disallowed universal selectors (#243)

### DIFF
--- a/components/images/images.css
+++ b/components/images/images.css
@@ -20,7 +20,20 @@
   background: linear-gradient(to top, rgba(0,0,0,0.65) 0%,rgba(0,0,0,0) 100%);
 }
 
-.ampstart-image-heading > * {
+.ampstart-image-heading > .h1,
+.ampstart-image-heading > .h2,
+.ampstart-image-heading > .h3,
+.ampstart-image-heading > .h4,
+.ampstart-image-heading > .h5,
+.ampstart-image-heading > .h6,
+.ampstart-image-heading > .ampstart-subtitle,
+.ampstart-image-heading > .caps,
+.ampstart-image-heading > h1,
+.ampstart-image-heading > h2,
+.ampstart-image-heading > h3,
+.ampstart-image-heading > h4,
+.ampstart-image-heading > h5,
+.ampstart-image-heading > h6 {
   margin: 0;
 }
 

--- a/components/navbar/navbar.css
+++ b/components/navbar/navbar.css
@@ -21,8 +21,22 @@
   box-shadow: 0 0 5px 2px rgba(0,0,0,.1);
 }
 
-.ampstart-headerbar + *:not(amp-sidebar),
-.ampstart-headerbar + amp-sidebar + * {
+.ampstart-headerbar + div,
+.ampstart-headerbar + figure,
+.ampstart-headerbar + section,
+.ampstart-headerbar + article,
+.ampstart-headerbar + main,
+.ampstart-headerbar + nav,
+.ampstart-headerbar + footer,
+.ampstart-headerbar + header,
+.ampstart-headerbar + amp-sidebar + div,
+.ampstart-headerbar + amp-sidebar + figure,
+.ampstart-headerbar + amp-sidebar + section,
+.ampstart-headerbar + amp-sidebar + article,
+.ampstart-headerbar + amp-sidebar + main,
+.ampstart-headerbar + amp-sidebar + nav,
+.ampstart-headerbar + amp-sidebar + footer,
+.ampstart-headerbar + amp-sidebar + header {
   margin-top: var(--navbar-height);
 }
 

--- a/css/ampstart-base/base-page.css
+++ b/css/ampstart-base/base-page.css
@@ -15,7 +15,22 @@
  */
 @import 'base-page-vars';
 
-* {
+amp-sidebar,
+div,
+section,
+input,
+textarea,
+select,
+label,
+button,
+.btn,
+.border,
+.border-top,
+.border-right,
+.border-bottom,
+.border-left,
+.ampstart-btn,
+.ampstart-input {
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
Replaced the 3 instances of the disallowed universal selector that were showing up in the starter templates with type &| class selectors likely to affected by those styles.
This could be improved with a little discussion.