### PR TITLE
removed id="content" (#338)

### DIFF
--- a/css/ampstart-base/base-page.css
+++ b/css/ampstart-base/base-page.css
@@ -52,7 +52,7 @@ p {
   color: var(--color-font-accent);
 }
 
-#content {
+#content:target {
   margin-top: calc(0px - var(--navbar-height));
   padding-top: var(--navbar-height);
 }

--- a/templates/blog.amp.html
+++ b/templates/blog.amp.html
@@ -21,7 +21,7 @@ limitations under the License.
   {{> ../utils/amp-page-head.snip.html}}
   <body>
     {{> ../components/navbar/navbar.snip.html}}
-    <main id="content" role="main" class="">
+    <main role="main" class="">
       <article class="recipe-article">
         <header>
           <span class="ampstart-accent block px3 pt2 mb2">FOOD</span>

--- a/templates/blog.amp.html
+++ b/templates/blog.amp.html
@@ -21,7 +21,7 @@ limitations under the License.
   {{> ../utils/amp-page-head.snip.html}}
   <body>
     {{> ../components/navbar/navbar.snip.html}}
-    <main role="main" class="">
+    <main id="content" role="main" class="">
       <article class="recipe-article">
         <header>
           <span class="ampstart-accent block px3 pt2 mb2">FOOD</span>


### PR DESCRIPTION
This is one way to keep the navbar from covering the accent above the heading (L27). It looks like this id isn't being referenced by anything else. Another option would be changing the style, but both themes rely on `#content`. 