### PR TITLE
Make .ampstart-btn use body font

### DIFF
--- a/css/ampstart-base/base-page.css
+++ b/css/ampstart-base/base-page.css
@@ -41,6 +41,11 @@ p {
   margin: 0;
 }
 
+button {
+  font-family: inherit;
+  font-weight: inherit;
+}
+
 /* Subtitle */
 .ampstart-subtitle {
   color: var(--color-font-subtitle);

--- a/css/ampstart-base/base-page.css
+++ b/css/ampstart-base/base-page.css
@@ -41,11 +41,6 @@ p {
   margin: 0;
 }
 
-button {
-  font-family: inherit;
-  font-weight: inherit;
-}
-
 /* Subtitle */
 .ampstart-subtitle {
   color: var(--color-font-subtitle);

--- a/css/ampstart-base/elements/buttons.css
+++ b/css/ampstart-base/elements/buttons.css
@@ -16,6 +16,8 @@
 
 /* Buttons */
 .ampstart-btn {
+  font-family: inherit;
+  font-weight: inherit;
   font-size: 1rem;
   line-height: var(--line-height-2);
   padding: 0.7em 0.8em;


### PR DESCRIPTION
The "VIEW TEMPLATE" and "DOWNLOAD CODE" buttons use a different font—"VIEW CODE" is Helvetica, whilst "DOWNLOAD CODE" is in Montserrat. (Interestingly this isn't true on https://ampstart.com, however the HTML is slightly different there—I'm guessing f7286b0d29db5289e227993fe39517345601d534 hasn't been deployed yet?)

This PR makes the font used by `<button class="ampstart-btn">…</button>` and `<a class="ampstart-btn">…</a>` match.

![screen shot 2017-03-22 at 11 22 07 pm](https://cloud.githubusercontent.com/assets/51244/24225718/e123195e-0f59-11e7-80cf-a2ea09d593aa.png)
![screen shot 2017-03-22 at 11 22 18 pm](https://cloud.githubusercontent.com/assets/51244/24225720/e6764336-0f59-11e7-9bc1-61728b87af92.png)
