### PR TITLE
Make "npm run $cmd" work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ install:
 - npm install -g firebase-tools
 - npm install
 script:
-- gulp build
+- npm run build
 after_success:
 - 'if [ "${TRAVIS_BRANCH}" = "production" ]; then firebase deploy --non-interactive --token "$FIREBASE_TOKEN" --project ampstart-8dc54; fi'
 - 'if [ "${TRAVIS_BRANCH}" = "master" ]; then firebase deploy --non-interactive --token "$FIREBASE_TOKEN" --project ampstart-staging; fi'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kickstart",
-  "script": {
+  "scripts": {
     "build": "gulp build",
     "clean": "gulp clean",
     "www": "gulp www",


### PR DESCRIPTION
Feels like I'm missing something here, but `npm run build` (and every other `npm run ...` command) fail for me:

```sh
$ npm run build
npm ERR! Darwin 16.4.0
npm ERR! argv "/Users/stillers/.local/share/node/versions/node-v7.6.0/bin/node" "/Users/stillers/.local/share/node/versions/node-v7.6.0/bin/npm" "run" "build"
npm ERR! node v7.6.0
npm ERR! npm  v4.1.2

npm ERR! missing script: build
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <https://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/stillers/workspace/ampstart/npm-debug.log
```

This seems to be because the `package.json` key is `script` instead of `scripts`. (Travis just runs `gulp build` directly, so maybe no-one noticed? Or maybe it's late and I'm doing it wrong?)