### PR TITLE
Fix for #420: Changed the min-width of sidebar to avoid text colliding with the edge of the side bar.

### DIFF
--- a/css/www/components/page.css
+++ b/css/www/components/page.css
@@ -21,7 +21,7 @@
   padding-top: var(--space-7);
   margin-top: calc(-1 * var(--space-7));
   box-shadow: 5px 0 5px -5px rgba(0,0,0,0.4);
-  min-width: 160px;
+  min-width: 200px;
 }
 
 .www-component-anchors {


### PR DESCRIPTION
#420 remove side nav before 833 px wide.
Changed the min-width of sidebar to avoid text colliding with the edge of the side bar.