### PR TITLE
Fix letter spacing + Template preview mask

### DIFF
--- a/components/lightbox/template-preview.css
+++ b/components/lightbox/template-preview.css
@@ -33,6 +33,7 @@
 .ampstart-device-preview-mask {
   background: var(--color-white);
   opacity: 0.8;
+  pointer-events: none;
 }
 
 .ampstart-device-preview-select {

--- a/css/ampstart-base/elements/typography.css
+++ b/css/ampstart-base/elements/typography.css
@@ -51,7 +51,7 @@ body {
   font-size: var(--h5);
   color: var(--color-font-subtitle);
   line-height: var(--line-height-2);
-  letter-spacing: .1rem
+  letter-spacing: .06rem;
 }
 
 .ampstart-label {
@@ -62,5 +62,5 @@ body {
 .ampstart-small-text {
   font-size: var(--h6);
   line-height: var(--line-height-1);
-  letter-spacing: .1rem
+  letter-spacing: .06rem;
 }


### PR DESCRIPTION
Make Letter spacing 0.06 rem except for the body
Clicking the template preview's mask should close the lightbox.