### PR TITLE
Fix <link rel=canonical> on /

### DIFF
--- a/www/index.json
+++ b/www/index.json
@@ -2,7 +2,7 @@
   "www-index": {
     "head-tag": {
       "title": "AMP Start - Accelarated Mobile Pages Templates",
-      "canonical-path": "https://www.ampstart.com/",
+      "canonical-path": "",
       "extensions": [
         "amp-carousel",
         "amp-sidebar",


### PR DESCRIPTION
Fixes `<link rel="canonical">` on https://www.ampstart.com/. Doesn't appear to change anything else:

```diff
$ diff dist dist2
Common subdirectories: dist/archive and dist2/archive
Common subdirectories: dist/css and dist2/css
Common subdirectories: dist/hl-partials and dist2/hl-partials
Common subdirectories: dist/img and dist2/img
diff dist/index.html dist2/index.html
8c8
<   <link rel="canonical" href="https://www.ampstart.com/https://www.ampstart.com/">
---
>   <link rel="canonical" href="https://www.ampstart.com/">
Common subdirectories: dist/render and dist2/render
Common subdirectories: dist/templates and dist2/templates
```
