### PR TITLE
Allow the right side of the ampstart-navbar to accept a link as well as calltracking

### DIFF
--- a/components/navbar/navbar.snip.html
+++ b/components/navbar/navbar.snip.html
@@ -58,11 +58,13 @@ limitations under the License.
     {{/sidebaronly}}
     {{#fixeditems}}
     <div class="ampstart-headerbar-fixed center m0 p0 mr2 flex justify-center nowrap">
-      {{#calltracking}}
-        {{> ../calltracking/calltracking.snip.html}}
-      {{/calltracking}}
+      <div class="ml1">
+        {{#calltracking}}
+          {{> ../calltracking/calltracking.snip.html}}
+        {{/calltracking}}
+      </div>
       {{#link}}
-        <a href="{{{url}}}" class="text-decoration-none px1 {{classes}}" {{#target}}target={{.}}{{/target}}>{{text}}</a>
+        <a href="{{{url}}}" class="text-decoration-none ml1 {{classes}}" {{#target}}target={{.}}{{/target}}>{{text}}</a>
       {{/link}}
     </div>
     {{/fixeditems}}

--- a/components/navbar/navbar.snip.html
+++ b/components/navbar/navbar.snip.html
@@ -61,6 +61,9 @@ limitations under the License.
       {{#calltracking}}
         {{> ../calltracking/calltracking.snip.html}}
       {{/calltracking}}
+      {{#link}}
+        <a href="{{{url}}}" class="text-decoration-none px1 {{classes}}" {{#target}}target={{.}}{{/target}}>{{text}}</a>
+      {{/link}}
     </div>
     {{/fixeditems}}
   </header>

--- a/components/navbar/navbar.snip.html
+++ b/components/navbar/navbar.snip.html
@@ -57,14 +57,14 @@ limitations under the License.
     </nav>
     {{/sidebaronly}}
     {{#fixeditems}}
-    <div class="ampstart-headerbar-fixed center m0 p0 mr2 flex justify-center nowrap">
-      <div class="ml1">
+    <div class="ampstart-headerbar-fixed center m0 p0 flex justify-center nowrap">
+      <div class="mr2">
         {{#calltracking}}
           {{> ../calltracking/calltracking.snip.html}}
         {{/calltracking}}
       </div>
       {{#link}}
-        <a href="{{{url}}}" class="text-decoration-none ml1 {{classes}}" {{#target}}target={{.}}{{/target}}>{{text}}</a>
+        <a href="{{{url}}}" class="text-decoration-none mr2 {{classes}}" {{#target}}target={{.}}{{/target}}>{{text}}</a>
       {{/link}}
     </div>
     {{/fixeditems}}


### PR DESCRIPTION
This simple pull request amends the navbar slightly to allow a link to be passed to the right side of the ampstart-navbar from json, which means the nav can accept:

* A link
* Calltracking
* Both

This allows the navbar to be slightly more flexible when dealing with different amp designs.

Note this PR is continuing from a previous PR found [here](https://github.com/ampproject/ampstart/pull/478)

Following from the previous PR, mr2 has been added to links, and removed from the ampstart-headerbar-fixed.

The spacing looks good, apart from on lower resolutions. The right container is position absolute, and therefore will overlap when there's too much copy. We may need to re-look at how the layout of the navbar elements to get around this. See the below screenshots

<img width="1367" alt="screen shot 2017-07-06 at 5 48 43 pm" src="https://user-images.githubusercontent.com/1872029/27968280-52a602de-633e-11e7-8933-58572d8d22b2.png">

<img width="644" alt="screen shot 2017-07-06 at 5 49 00 pm" src="https://user-images.githubusercontent.com/1872029/27968286-594a5d7e-633e-11e7-89ed-3511ed5b48db.png">

