### PR TITLE
Added aria-label for HTML Code amp-accordian Section for Talkback

### DIFF
--- a/www/components.html
+++ b/www/components.html
@@ -74,7 +74,7 @@ limitations under the License.
             {{#code-file}}
             <div class="www-example-code mb4">
               <amp-accordion disable-session-states>
-                <section>
+                <section aria-label="Collapsed HTML Code for Amp Start UI Component">
                   <h3 class="caps h4 border-none py2">HTML</h3>
                   <!-- HTML markup used to render the element/component -->
                   <div class="pb2">


### PR DESCRIPTION
closes #389 

Simply adds an aria label for the HTML Code, Tested on Talkback