### PR TITLE
Fixed Serve Errors for gulpfile, Improved Watch build times, and Added livereload to serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AMP Start is built on top of [Basscss](http://basscss.com/) a low-level CSS tool
 | `npm run www`                                                              | Recompile www to build directory.                                     |
 | `npm run highlight`                                                        | Build HTML for code highlighting.                                     |
 | `npm run watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
-| `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/.|
+| `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Also watches changes for development. |
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AMP Start is built on top of [Basscss](http://basscss.com/) a low-level CSS tool
 | `npm run www`                                                              | Recompile www to build directory.                                     |
 | `npm run highlight`                                                        | Build HTML for code highlighting.                                     |
 | `npm run watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-builds development files.             |
-| `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Also, watches/livereloads for file changes. |
+| `npm run serve`                                                            | Serves content in repo dist/ dir over http://localhost:8000/. Also, watches/livereloads for file changes. |
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ AMP Start is built on top of [Basscss](http://basscss.com/) a low-level CSS tool
 | `npm run clean`                                                            | Removes build output.                                                 |
 | `npm run www`                                                              | Recompile www to build directory.                                     |
 | `npm run highlight`                                                        | Build HTML for code highlighting.                                     |
-| `npm run watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
+| `npm run watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-builds development files.             |
 | `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Also, watches/livereloads for file changes. |
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ AMP Start is built on top of [Basscss](http://basscss.com/) a low-level CSS tool
 | `npm run www`                                                              | Recompile www to build directory.                                     |
 | `npm run highlight`                                                        | Build HTML for code highlighting.                                     |
 | `npm run watch`<sup>[[1]](#footnote-1)</sup>                               | Watches for changes in files, re-build.                               |
-| `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Also watches changes for development. |
+| `npm run serve`                                                            | Serves content in repo root dir over http://localhost:8000/. Also, watches/livereloads for file changes. |
 
 <a id="footnote-1">[1]</a> On Windows, this command must be run as administrator.
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,9 @@ gulp.task('watch', 'watch stuff', ['build'], function() {
         config.src.components, config.src.templates, config.src.www_pages,
         config.src.css, config.src.data, config.src.img
       ],
-      ['img', 'postcss', 'posthtml', 'www', 'validate']);
+      function(event) {
+        runSequence(['img', 'postcss'], ['www', 'posthtml'], 'validate');
+      });
 });
 
 gulp.task('default', ['build']);

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -163,18 +163,7 @@ gulp.task('www', function() {
       .pipe(gulp.dest(config.dest.www_pages))
 });
 
-gulp.task('watch:www', 'watch stuff, similar to watchdev, but includes bundling and validation', ['build'], function() {
-  return gulp.watch(
-      [
-        config.src.components, config.src.templates, config.src.www_pages,
-        config.src.css, config.src.data, config.src.img
-      ],
-      function(event) {
-        runSequence(['img', 'postcss'], ['www', 'posthtml'], 'validate', 'bundle');
-      });
-});
-
-gulp.task('watch:dev', 'watch stuff, minimal watching for development', ['build'], function() {
+gulp.task('watch:www', 'watch stuff, minimal watching for development', ['build'], function() {
   return gulp.watch(
       [
         config.src.components, config.src.templates, config.src.www_pages,
@@ -222,13 +211,6 @@ gulp.task('postcss', 'build postcss files', function() {
 });
 
 gulp.task('serve', 'Host a livereloading webserver for the project', ['watch:www'], function() {
-  gulp.src(config.dest.default).pipe(server({
-    livereload: true,
-    directoryListing: {enable: true, path: 'dist'},
-  }));
-});
-
-gulp.task('serve:dev', 'Host a livereloading webserver for the project', ['watch:dev'], function() {
   gulp.src(config.dest.default).pipe(server({
     livereload: true,
     directoryListing: {enable: true, path: 'dist'},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -169,7 +169,7 @@ gulp.task('watch', 'watch stuff', ['build'], function() {
         config.src.components, config.src.templates, config.src.www_pages,
         config.src.css, config.src.data, config.src.img
       ],
-      ['build']);
+      ['img', 'postcss', 'posthtml', 'www', 'validate']);
 });
 
 gulp.task('default', ['build']);
@@ -208,7 +208,7 @@ gulp.task('postcss', 'build postcss files', function() {
       .pipe(gulp.dest(config.dest.css))
 });
 
-gulp.task('serve', function() {
+gulp.task('serve', 'Host a livereloading webserver for the project', ['watch'], function() {
   gulp.src(config.dest.default).pipe(server({
     livereload: true,
     directoryListing: {enable: true, path: 'dist'},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -163,29 +163,18 @@ gulp.task('www', function() {
       .pipe(gulp.dest(config.dest.www_pages))
 });
 
-gulp.task('watchwww', 'watch stuff, similar to watchdev, but includes bundling and validation', ['build'], function() {
+gulp.task('watch:www', 'watch stuff, similar to watchdev, but includes bundling and validation', ['build'], function() {
   return gulp.watch(
       [
         config.src.components, config.src.templates, config.src.www_pages,
         config.src.css, config.src.data, config.src.img
       ],
       function(event) {
-        runSequence('clean', ['img', 'postcss'], ['www', 'posthtml'], 'validate', 'bundle');
+        runSequence(['img', 'postcss'], ['www', 'posthtml'], 'validate', 'bundle');
       });
 });
 
-gulp.task('watchdev', 'watch stuff, minimal watching for development', ['build'], function() {
-  return gulp.watch(
-      [
-        config.src.components, config.src.templates, config.src.www_pages,
-        config.src.css, config.src.data, config.src.img
-      ],
-      function(event) {
-        runSequence(['img', 'postcss'], ['www', 'posthtml'], 'validate');
-      });
-});
-
-gulp.task('watch', 'watch stuff', ['build'], function() {
+gulp.task('watch:dev', 'watch stuff, minimal watching for development', ['build'], function() {
   return gulp.watch(
       [
         config.src.components, config.src.templates, config.src.www_pages,
@@ -232,14 +221,14 @@ gulp.task('postcss', 'build postcss files', function() {
       .pipe(gulp.dest(config.dest.css))
 });
 
-gulp.task('serve', 'Host a livereloading webserver for the project', ['watchwww'], function() {
+gulp.task('serve', 'Host a livereloading webserver for the project', ['watch:www'], function() {
   gulp.src(config.dest.default).pipe(server({
     livereload: true,
     directoryListing: {enable: true, path: 'dist'},
   }));
 });
 
-gulp.task('servedev', 'Host a livereloading webserver for the project', ['watchdev'], function() {
+gulp.task('serve:dev', 'Host a livereloading webserver for the project', ['watch:dev'], function() {
   gulp.src(config.dest.default).pipe(server({
     livereload: true,
     directoryListing: {enable: true, path: 'dist'},

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -163,6 +163,28 @@ gulp.task('www', function() {
       .pipe(gulp.dest(config.dest.www_pages))
 });
 
+gulp.task('watchwww', 'watch stuff, similar to watchdev, but includes bundling and validation', ['build'], function() {
+  return gulp.watch(
+      [
+        config.src.components, config.src.templates, config.src.www_pages,
+        config.src.css, config.src.data, config.src.img
+      ],
+      function(event) {
+        runSequence('clean', ['img', 'postcss'], ['www', 'posthtml'], 'validate', 'bundle');
+      });
+});
+
+gulp.task('watchdev', 'watch stuff, minimal watching for development', ['build'], function() {
+  return gulp.watch(
+      [
+        config.src.components, config.src.templates, config.src.www_pages,
+        config.src.css, config.src.data, config.src.img
+      ],
+      function(event) {
+        runSequence(['img', 'postcss'], ['www', 'posthtml'], 'validate');
+      });
+});
+
 gulp.task('watch', 'watch stuff', ['build'], function() {
   return gulp.watch(
       [
@@ -210,7 +232,14 @@ gulp.task('postcss', 'build postcss files', function() {
       .pipe(gulp.dest(config.dest.css))
 });
 
-gulp.task('serve', 'Host a livereloading webserver for the project', ['watch'], function() {
+gulp.task('serve', 'Host a livereloading webserver for the project', ['watchwww'], function() {
+  gulp.src(config.dest.default).pipe(server({
+    livereload: true,
+    directoryListing: {enable: true, path: 'dist'},
+  }));
+});
+
+gulp.task('servedev', 'Host a livereloading webserver for the project', ['watchdev'], function() {
   gulp.src(config.dest.default).pipe(server({
     livereload: true,
     directoryListing: {enable: true, path: 'dist'},

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "clean": "gulp clean",
     "www": "gulp www",
     "highlight": "gulp highlight",
-    "watch": "gulp watch",
+    "watch": "gulp watch:www",
     "serve": "gulp serve"
   },
   "private": true,

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -21,8 +21,6 @@ const config = require('./config');
 function validate() {
   return gulp.src([
         `${config.dest.templates}/**/*.html`,
-        `${config.dest.www_pages}/**/*.html`,
-        `!${config.dest.templates}/components/**/*.html`,
         `!${config.dest.hl_partials}/**/*.html`,
       ])
       .pipe(validator.validate())


### PR DESCRIPTION
closes #472 

This fixes the gulp watch hanging, as well as improves the watch task by removing some unnecessary build tasks from the watch task, and parallelizing other tasks.

Also in `tasks/validate.js` I removed some redundant/unneccesary globs, therefore slightly speeding up build times.