### PR TITLE
Nit visual changes to article template

### DIFF
--- a/components/images/fullpage-hero.css
+++ b/components/images/fullpage-hero.css
@@ -22,7 +22,7 @@
 .ampstart-image-fullpage-hero .ampstart-image-credit {
   box-decoration-break: clone;
   background: var(--color-primary);
-  padding: 0 var(--space-2) 0.2rem;
+  padding: 0.4rem;
 }
 
 .ampstart-image-fullpage-hero > amp-img {
@@ -52,10 +52,12 @@
   display: block;
   content: '⌄';
   font-size: var(--h2);
+  margin-top: 0.5rem;
 }
 
 .ampstart-readmore-text {
   background: var(--color-primary);
+  padding: 0.5rem;
 }
 
 @media (--breakpoint-md) {

--- a/css/ampstart-base/elements/initialcap.css
+++ b/css/ampstart-base/elements/initialcap.css
@@ -23,5 +23,8 @@
   color: var(--color-font-secondary);
   font-size: var(--h1);
   font-weight: var(--bold-font-weight);
-  margin-left: -2px;
+  margin-left: -7px;
+  margin-top: 7px;
+  padding: 5px;
+  float: left;
 }


### PR DESCRIPTION
### Changes
- Makes the heading's black highlight and read more button a bit more symmetric
- Gives a better initial cap letter.

Before:

<kbd><img width="366" alt="screen shot 2017-07-11 at 9 13 59 pm" src="https://user-images.githubusercontent.com/591655/28101529-ed6567f0-667d-11e7-825f-d472fcd92319.png"></kbd>

After:

<kbd><img width="364" alt="screen shot 2017-07-11 at 9 13 46 pm" src="https://user-images.githubusercontent.com/591655/28101534-f42a2468-667d-11e7-96c2-e25a1ae7a7d4.png"></kbd>


Before:

<kbd><img width="354" alt="screen shot 2017-07-11 at 9 10 02 pm" src="https://user-images.githubusercontent.com/591655/28101444-608223f0-667d-11e7-91c0-82c8d34f0ae1.png"></kbd>

After:

<kbd><img width="337"  border="5" alt="screen shot 2017-07-11 at 8 53 50 pm" src="https://user-images.githubusercontent.com/591655/28101443-607fcf56-667d-11e7-8fa7-8f777998304e.png"></kbd>

