### PR TITLE
[navbar] fix click events on sidebar toggle when using a custom svg-icon in IE11

### DIFF
--- a/components/navbar/navbar.css
+++ b/components/navbar/navbar.css
@@ -137,3 +137,7 @@
 .ampstart-sidebar .ampstart-navbar-trigger {
   line-height: inherit;
 }
+
+.ampstart-headerbar .ampstart-navbar-trigger svg {
+  pointer-events: none;
+}

--- a/components/navbar/navbar.css
+++ b/components/navbar/navbar.css
@@ -138,6 +138,6 @@
   line-height: inherit;
 }
 
-.ampstart-headerbar .ampstart-navbar-trigger svg {
+.ampstart-navbar-trigger svg {
   pointer-events: none;
 }


### PR DESCRIPTION
See related issue #526 .

Setting `pointer-events: none` allows the click event to propagate to its wrapper and toggle the sidebar.