### PR TITLE
Removed Redundant Dependencies, and Created A Count CSS Task

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -116,7 +116,7 @@ function getPartials(acc, embedderDir, template) {
 
 gulp.task('build', 'build', function(cb) {
   runSequence(
-      'clean', 'highlight', 'escape', 'img', 'templateapi', 'postcss', 'posthtml', 'www', 'validate',
+      'clean', 'highlight', 'escape', 'img', 'templateapi', 'postcss', 'countcss', 'posthtml', 'www', 'validate',
       'bundle', cb);
 });
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "fs-extra": "^2.0.0",
     "gulp": "^3.9.1",
     "gulp-amphtml-validator": "1.0.0",
-    "gulp-ext-replace": "^0.3.0",
     "gulp-help": "^1.6.1",
     "gulp-postcss": "^6.2.0",
     "gulp-posthtml": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "gulp-amphtml-validator": "1.0.0",
     "gulp-ext-replace": "^0.3.0",
     "gulp-help": "^1.6.1",
-    "gulp-intercept": "^0.1.0",
     "gulp-postcss": "^6.2.0",
     "gulp-posthtml": "^2.0.0",
     "gulp-rename": "^1.2.2",

--- a/tasks/configurator.js
+++ b/tasks/configurator.js
@@ -20,7 +20,7 @@ const util = require('gulp-util');
 const postcss = require('gulp-postcss');
 const replace = require('gulp-replace');
 const csstree = require('css-tree');
-const extReplace = require('gulp-ext-replace');
+const rename = require('gulp-rename');
 const through = require('through2');
 
 function postCssWithVars() {
@@ -63,7 +63,9 @@ function cssVarsJson() {
         file.contents = new Buffer(JSON.stringify(cssVarObj, null, 2));
         cb(null, file);
       }))
-      .pipe(extReplace('.json'))
+      .pipe(rename(function(path) {
+        path.extname = ".json";
+      }))
       .pipe(gulp.dest(config.dest.uncompiled_css))
 }
 

--- a/tasks/configurator.js
+++ b/tasks/configurator.js
@@ -21,7 +21,7 @@ const postcss = require('gulp-postcss');
 const replace = require('gulp-replace');
 const csstree = require('css-tree');
 const extReplace = require('gulp-ext-replace');
-const intercept = require('gulp-intercept');
+const through = require('through2');
 
 function postCssWithVars() {
   const plugins = [
@@ -45,21 +45,23 @@ function postCssWithVars() {
 
 function cssVarsJson() {
   return gulp.src(config.dest.uncompiled_css + '/**/*.css')
-      .pipe(intercept(function(file) {
-        if (file.contents) {
-          const cssVarObj = {};
-          const ast = csstree.parse(file.contents.toString());
-          csstree.walk(ast, function(node) {
-            if(node.type === 'Declaration' && node.property.indexOf('--') === 0) {
-              cssVarObj[node.property] = {
-                value: node.value.value
-              }
-            }
-          });
-          // Place the json into the file
-          file.contents = new Buffer(JSON.stringify(cssVarObj, null, 2));
-          return file;
+      .pipe(through.obj(function(file, enc, cb) {
+        if(file.isNull()) {
+          cb(null, file);
+          return;
         }
+        const cssVarObj = {};
+        const ast = csstree.parse(file.contents.toString());
+        csstree.walk(ast, function(node) {
+          if(node.type === 'Declaration' && node.property.indexOf('--') === 0) {
+            cssVarObj[node.property] = {
+              value: node.value.value
+            }
+          }
+        });
+        // Place the json into the file
+        file.contents = new Buffer(JSON.stringify(cssVarObj, null, 2));
+        cb(null, file);
       }))
       .pipe(extReplace('.json'))
       .pipe(gulp.dest(config.dest.uncompiled_css))

--- a/tasks/countCss.js
+++ b/tasks/countCss.js
@@ -1,0 +1,38 @@
+/**
+ * Copyright 2017 The AMP Start Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const gulp = require('gulp-help')(require('gulp'));
+const config = require('./config');
+const rename = require('gulp-rename');
+const through = require('through2');
+
+function escape() {
+  return gulp.src(config.src.hl_partials)
+    .pipe(rename(function(path) {
+      path.basename = `esc-${path.basename}`;
+    }))
+    .pipe(through.obj(function(file, enc, cb) {
+      if (file.isNull()) {
+        cb(null, file);
+        return;
+      }
+      file.contents = new Buffer(escapehtml(file.contents.toString()));
+      cb(null, file);
+    }))
+    .pipe(gulp.dest(config.dest.hl_partials));
+}
+
+gulp.task('countcss', escape);

--- a/tasks/countCss.js
+++ b/tasks/countCss.js
@@ -35,7 +35,9 @@ function countCss() {
       const exponent = Math.min(Math.floor(Math.log10(numChars) / 3), byteSizes.length - 1);
       const size = Number(numChars / Math.pow(1000, exponent)).toPrecision(4);
       file.contents =
-        new Buffer(`Number of characters: ${numChars}\nSize: ${size} ${byteSizes[exponent]}`);
+        new Buffer(`File name: ${file.relative}\n` +
+          `Number of characters: ${numChars}\n` +
+          `Size: ${size} ${byteSizes[exponent]}`);
       cb(null, file);
     }))
     .pipe(rename(function(path) {

--- a/tasks/countCss.js
+++ b/tasks/countCss.js
@@ -19,20 +19,30 @@ const config = require('./config');
 const rename = require('gulp-rename');
 const through = require('through2');
 
-function escape() {
+//Define our Byte Sizes
+const byteSizes = ["B", "KB", "MB", "GB", "TB"];
+
+function countCss() {
   return gulp.src(config.src.css)
-    .pipe(rename(function(path) {
-      path.basename = `esc-${path.basename}`;
-    }))
     .pipe(through.obj(function(file, enc, cb) {
       if (file.isNull()) {
         cb(null, file);
         return;
       }
-      file.contents = new Buffer(escapehtml(file.contents.toString()));
+
+      // Count the number of Characters/Bytes in the file
+      const numChars = file.contents.toString().length;
+      const exponent = Math.min(Math.floor(Math.log10(numChars) / 3), byteSizes.length - 1);
+      const size = Number(numChars / Math.pow(1000, exponent)).toPrecision(4);
+      file.contents =
+        new Buffer(`Number of characters: ${numChars}\nSize: ${size} ${byteSizes[exponent]}`);
       cb(null, file);
     }))
-    .pipe(gulp.dest(config.dest.hl_partials));
+    .pipe(rename(function(path) {
+      path.basename = `size-${path.basename}`;
+      path.extname = ".txt";
+    }))
+    .pipe(gulp.dest(config.dest.css));
 }
 
-gulp.task('countcss', escape);
+gulp.task('countcss', 'Count the amount of characters in the CSS of pages and templates.', countCss);

--- a/tasks/countCss.js
+++ b/tasks/countCss.js
@@ -20,7 +20,7 @@ const rename = require('gulp-rename');
 const through = require('through2');
 
 function escape() {
-  return gulp.src(config.src.hl_partials)
+  return gulp.src(config.src.css)
     .pipe(rename(function(path) {
       path.basename = `esc-${path.basename}`;
     }))

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -17,5 +17,6 @@
 require('./validate');
 require('./highlight');
 require('./escape');
+require('./countCss');
 require('./configurator');
 require('./bundle');


### PR DESCRIPTION
- Removed the dependencies `gulp-intercept` and `gulp-ext-rename`
- Created a task to count the number of characters in css with dist/ and output it's size in both number of characters, and bytes

cc @camelburrito are there any relevant issues for this? Also, let me know if this should be output to dist/ or src/ since I know you wanted to use this as a PR tool.

Example Output:

````
File name: core.css
Number of characters: 2139
Size: 2.139 KB
````
