### PR TITLE
[LUNE] - Landing page QA

### DIFF
--- a/css/templates/lune/components/_cta.css
+++ b/css/templates/lune/components/_cta.css
@@ -9,6 +9,8 @@
   background: transparent;
   letter-spacing: var(--letter-spacing-3);
   font-weight: 700;
+  /* Force a new GPU layer — fixes some glitches */
+  backface-visibility: hidden;
 }
 
 .ampstart-btn,

--- a/css/templates/lune/pages/_landing.css
+++ b/css/templates/lune/pages/_landing.css
@@ -118,6 +118,11 @@
    */
   @supports (clip-path: inset(1px 0)) {
     .lune-landing-section.lune-theme-light {
+      /*
+       * Using the old clip spec too, as it works better in some browser.
+       * Requires the element to have position:absolute.
+       */
+      clip: rect(0 auto auto 0);
       clip-path: url(#svgClipPath);
       /*
        * We need the height to be a bit more than its normal value (hence the 0.99 factor),
@@ -127,8 +132,18 @@
       height: calc(var(--lune-landing-page-height) / 0.99);
     }
 
-    .lune-landing-wrapper {
+    .lune-landing-content {
       position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+    }
+
+    .lune-page-landing .lune-component-scroll-indicator {
+      position: fixed;
+      bottom: 0;
+      left: 50%;
+      transform: translate(-50%);
     }
   }
 }

--- a/templates/lune/lune.amp.html
+++ b/templates/lune/lune.amp.html
@@ -33,7 +33,7 @@ limitations under the License.
     <div class="lune-page lune-page-landing">
       {{#landing-sections}}
         <!-- Landing section -->
-        <section class="lune-landing-section {{classes}}">
+        <section class="lune-landing-section top-0 left-0 right-0 {{classes}}">
           <div class="lune-landing-wrapper absolute top-0 left-0 bottom-0 right-0 flex flex-column items-center justify-center">
             <!-- Used by screen reader / document outline, not visible -->
             <h2 class="hide">{{full_title}}</h2>

--- a/templates/lune/lune.amp.json
+++ b/templates/lune/lune.amp.json
@@ -10,7 +10,7 @@
 
   "landing-sections": [
     {
-      "classes": "z2 relative lune-theme-light",
+      "classes": "z2 absolute lune-theme-light",
       "full_title": "Lune blanc",
       "product_image": {
         "alt": "Lune Blanc",
@@ -30,7 +30,7 @@
       }
     },
     {
-      "classes": "z1 relative top-0 left-0 right-0 bottom-0 lune-theme-dark",
+      "classes": "z1 relative lune-theme-dark",
       "full_title": "Lune noir",
       "product_image": {
         "alt": "Lune Noir",


### PR DESCRIPTION
This PR contains a few bugfixes to the landing page, in particular to the clipping effect.

We are now using both the old `clip` property and the more recent `clip-path` property, plus a couple of changes on positioning. These changes fix a couple of cross-browser bugs related mainly to rendering glitches and pointer events.