### PR TITLE
Created a Browserify Gulp Task for the AMP Start Configurator

### DIFF
--- a/css/CSS_SIZES.md
+++ b/css/CSS_SIZES.md
@@ -1,17 +1,17 @@
 | Filename                      | Number of Characters | Size     |
 | ----------------------------- | -------------------- | -------- |
 | core.css                      | 13784                | 13.78 KB |
-| templates/alp/page.css        | 24682                | 24.68 KB |
-| templates/article/page.css    | 24211                | 24.21 KB |
-| templates/blog/page.css       | 24454                | 24.45 KB |
-| templates/e-commerce/page.css | 38325                | 38.33 KB |
-| templates/lune/page.css       | 41540                | 41.54 KB |
-| templates/test/page.css       | 24297                | 24.30 KB |
-| templates/themes_1/page.css   | 25879                | 25.88 KB |
-| templates/themes_2/page.css   | 24786                | 24.79 KB |
-| templates/thescenic/page.css  | 24305                | 24.30 KB |
+| templates/alp/page.css        | 24298                | 24.30 KB |
+| templates/article/page.css    | 23827                | 23.83 KB |
+| templates/blog/page.css       | 24070                | 24.07 KB |
+| templates/e-commerce/page.css | 37791                | 37.79 KB |
+| templates/lune/page.css       | 41313                | 41.31 KB |
+| templates/test/page.css       | 23913                | 23.91 KB |
+| templates/themes_1/page.css   | 25481                | 25.48 KB |
+| templates/themes_2/page.css   | 24402                | 24.40 KB |
+| templates/thescenic/page.css  | 23921                | 23.92 KB |
 | www/components/page.css       | 22712                | 22.71 KB |
 | www/getstarted/page.css       | 17945                | 17.95 KB |
 | www/howitworks/page.css       | 17945                | 17.95 KB |
 | www/index/page.css            | 22125                | 22.13 KB |
-| www/render/page.css           | 24244                | 24.24 KB |
+| www/render/page.css           | 23860                | 23.86 KB |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "basscss-responsive-margin": "^1.1.0",
     "basscss-responsive-padding": "^1.1.0",
     "basscss-responsive-type-scale": "^1.0.1",
+    "browserify": "^14.4.0",
     "child_process": "^1.0.2",
     "css-tree": "1.0.0-alpha19",
     "cssbeautify": "^0.3.1",
@@ -51,12 +52,14 @@
     "posthtml-include": "^1.1.0",
     "posthtml-inline-assets": "^2.0.0",
     "run-sequence": "^1.1.5",
-    "through2": "2.0.3"
+    "through2": "2.0.3",
+    "vinyl-source-stream": "^1.1.0"
   },
   "dependencies": {
     "basscss": "^8.0.3",
     "basscss-addons": "^1.0.0",
     "basscss-basic": "^1.0.0",
-    "normalize.css": "^5.0.0"
+    "normalize.css": "^5.0.0",
+    "pretty-bytes": "^4.0.2"
   }
 }

--- a/tasks/config.js
+++ b/tasks/config.js
@@ -22,7 +22,10 @@ module.exports = {
       '!templates/**/partials/**/*.html'
     ],
     templateApi: 'templates/*/api/*.json',
-    www_pages: 'www/**/*.html',
+    www_pages: [
+      'www/**/*.html',
+      '!www/configurator/**/*.html'
+    ],
     hl_partials: 'hl-partials/**/*.html',
     css: ['css/**/*.css'],
     css_ignore: ['!css/**/_*.css', '!css/ampstart-base/**/*.css'],

--- a/tasks/config.js
+++ b/tasks/config.js
@@ -28,6 +28,7 @@ module.exports = {
     css_ignore: ['!css/**/_*.css', '!css/ampstart-base/**/*.css'],
     data: ['*/**/*.json', '!templates/*/data/*.json'],
     img: 'img/**',
+    configurator_app: 'www/configurator/src',
   },
   dest: {
     default: 'dist',

--- a/tasks/configuratorBundle.js
+++ b/tasks/configuratorBundle.js
@@ -16,6 +16,7 @@
 
  const gulp = require('gulp-help')(require('gulp'));
  const config = require('./config');
+ const path = require('path');
  const source = require('vinyl-source-stream');
  const browserify = require('browserify');
  //https://github.com/babel/babelify
@@ -28,10 +29,19 @@
     entries: entryPoint,
     debug: true
   });
-  
+
    return gulpBrowserify.bundle()
      .pipe(source('bundle.js'))
      .pipe(gulp.dest(config.dest.configurator_app));
  }
 
+ function configuratorCopy() {
+   return gulp.src([
+     path.join(config.src.configurator_app, '/**/*'),
+     path.join(`!${config.src.configurator_app}`, '/**/*.{css,js}')
+   ])
+   .pipe(gulp.dest(config.dest.configurator_app));
+ }
+
  gulp.task('configurator:bundle', 'Bundle dependencies for the configurator using browserify', configuratorBundle);
+ gulp.task('configurator:copy', 'Copy static files to the built configurator directory', configuratorCopy);

--- a/tasks/configuratorBundle.js
+++ b/tasks/configuratorBundle.js
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2017 The AMP Start Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ const gulp = require('gulp-help')(require('gulp'));
+ const config = require('./config');
+ const source = require('vinyl-source-stream');
+ const browserify = require('browserify');
+ //https://github.com/babel/babelify
+
+ function configuratorBundle() {
+
+   const entryPoint = config.src.configurator_app + '/index.js';
+  // https://github.com/gulpjs/gulp/blob/master/docs/recipes/browserify-transforms.md
+  const gulpBrowserify = browserify({
+    entries: entryPoint,
+    debug: true
+  });
+  
+   return gulpBrowserify.bundle()
+     .pipe(source('bundle.js'))
+     .pipe(gulp.dest(config.dest.configurator_app));
+ }
+
+ gulp.task('configurator:bundle', 'Bundle dependencies for the configurator using browserify', configuratorBundle);

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -19,4 +19,5 @@ require('./highlight');
 require('./escape');
 require('./countCss');
 require('./configurator');
+require('./configuratorBundle');
 require('./bundle');

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -22,6 +22,7 @@ function validate() {
   return gulp.src([
         `${config.dest.templates}/**/*.html`,
         `!${config.dest.hl_partials}/**/*.html`,
+        `!${config.dest.configurator_app}/**/*.html`,
       ])
       .pipe(validator.validate())
       .pipe(validator.format())

--- a/www/configurator/src/index.html
+++ b/www/configurator/src/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Amp Start Configurator</title>
+  </head>
+  <body>
+
+    See JS Console for manual tests
+
+  <script src="./bundle.js" type="text/javascript"></script>
+  </body>
+</html>

--- a/www/configurator/src/index.js
+++ b/www/configurator/src/index.js
@@ -1,0 +1,6 @@
+const prettyBytes = require('pretty-bytes');
+const browserifyTest = prettyBytes(2424);
+console.log('------------------------------');
+console.log('Configurator Testing:');
+console.log('------------------------------');
+console.log('Browserify Test', browserifyTest);


### PR DESCRIPTION
* Include Browserify into the project, as well as some `preety-bytes` for testing
* Creates a simple test page for testing our configurator tasks
* Creates a gulp for bundling JS using Browserify
* Creates a gulp task for copying static files from configurator/src to the build directory

# Screenshot
![screen shot 2017-07-24 at 5 31 56 pm](https://user-images.githubusercontent.com/1448289/28550513-32d377ce-7096-11e7-9892-d3e160f5ba99.png)
