### PR TITLE
Added the example baseline AMP Start configurator

### DIFF
--- a/tasks/config.js
+++ b/tasks/config.js
@@ -28,6 +28,7 @@ module.exports = {
     css_ignore: ['!css/**/_*.css', '!css/ampstart-base/**/*.css'],
     data: ['*/**/*.json', '!templates/*/data/*.json'],
     img: 'img/**',
+    configurator_app: 'www/configurator'
   },
   dest: {
     default: 'dist',

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -22,6 +22,7 @@ function validate() {
   return gulp.src([
         `${config.dest.templates}/**/*.html`,
         `!${config.dest.hl_partials}/**/*.html`,
+        `!${config.dest.configurator_app}/**/*.html`,
       ])
       .pipe(validator.validate())
       .pipe(validator.format())

--- a/www/configurator/src/app/hello.js
+++ b/www/configurator/src/app/hello.js
@@ -1,4 +1,4 @@
 export function hello() {
   console.log(document);
-  document.getElementById('hello-test').innerHTML = 'Hello, from Amp Start hello.js!';
+  document.getElementById('hello-test').textContent = 'Hello, from Amp Start hello.js!';
 }

--- a/www/configurator/src/app/hello.js
+++ b/www/configurator/src/app/hello.js
@@ -1,0 +1,4 @@
+export function hello() {
+  console.log(document);
+  document.getElementById('hello-test').innerHTML = 'Hello, from Amp Start hello.js!';
+}

--- a/www/configurator/src/app/hello.spec.js
+++ b/www/configurator/src/app/hello.spec.js
@@ -1,0 +1,7 @@
+/* eslint-env jasmine */
+describe('karma testing', () => {
+  it('should pass', () => {
+    console.log('hello!');
+    expect(true).toEqual(true);
+  });
+});

--- a/www/configurator/src/index.css
+++ b/www/configurator/src/index.css
@@ -1,0 +1,3 @@
+body {
+  background-color: lightgrey;
+}

--- a/www/configurator/src/index.html
+++ b/www/configurator/src/index.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>AMPStart Configurator</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width">
+    <link rel="icon" type="image/png" href="https://ampstart.com/img/www/amp_favicon.png" />
+  </head>
+  <body>
+    <!--[if lt IE 10]>
+      <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+    <![endif]-->
+
+    <div>
+      <h1>Amp Start Configurator</h1>
+      <h3 id="hello-test">
+        Hello
+      </h3>
+      <form>
+      </form>
+
+      <div id="root">
+      </div>
+    </div>
+  </body>
+</html>

--- a/www/configurator/src/index.js
+++ b/www/configurator/src/index.js
@@ -1,0 +1,46 @@
+import {hello} from './app/hello';
+import './index.css';
+
+let templatesPath = '';
+if (process.env.NODE_ENV === 'production') {
+  templatesPath = '../templates/';
+} else {
+  templatesPath = 'testTemplates/';
+}
+
+// Can only apply styles to iframe if on same domain
+// https://stackoverflow.com/questions/217776/how-to-apply-css-to-iframe
+// https://stackoverflow.com/questions/6494721/css-override-body-style-for-content-in-iframe
+
+class AmpConfigurator {
+  constructor() {
+    this.iframe = document.createElement('iframe');
+    this.iframe.setAttribute('width', '368px');
+    this.iframe.setAttribute('height', '600px');
+    document.getElementById('root').appendChild(this.iframe);
+  }
+
+  setSrc(path, iframeLoadedCallback) {
+    this.iframe.src = path;
+    this.iframe.addEventListener('load', () => {
+      if (iframeLoadedCallback) {
+        iframeLoadedCallback();
+      }
+    });
+  }
+
+  setStyle() {
+    this.style = this.iframe.contentDocument.createElement('style');
+    this.style.textContent = 'body { padding-left: 100px !important; }';
+    this.iframe.contentDocument.head.appendChild(this.style);
+  }
+}
+
+// require('postcss-custom-properties')({preserve: true}),
+const configurator = new AmpConfigurator();
+configurator.setSrc('https://www.google.com/images/branding/googlelogo/2x/googlelogo_color_272x92dp.png');
+configurator.setSrc(templatesPath + 'article/article.amp.html#amp=1', () => {
+  configurator.setStyle();
+});
+
+hello();

--- a/www/configurator/src/index.spec.js
+++ b/www/configurator/src/index.spec.js
@@ -1,0 +1,2 @@
+const context = require.context('./app', true, /\.(js|ts|tsx)$/);
+context.keys().forEach(context);


### PR DESCRIPTION
Relates to #512 

In the plan the @erwinmombay and @camelburrito and I agreed upon I am beginning work on starting the AMP Start Configurator.

The Steps are as follows:

1. Include an example project that uses ES6, HTML, And support for tests.
2. Build a webpack configuration to build the project using babel
3. Get a test suite up and running using Karma
4. Allow for Watching the project, with livereload, for efficient development.

This PR will accomplish Step One.