### PR TITLE
Built the webpack config for the AMP Start Configurator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ npm-debug.log
 .vscode
 .archive
 .idea
+**/.tmp

--- a/package.json
+++ b/package.json
@@ -51,12 +51,34 @@
     "posthtml-include": "^1.1.0",
     "posthtml-inline-assets": "^2.0.0",
     "run-sequence": "^1.1.5",
-    "through2": "2.0.3"
+    "through2": "2.0.3",
+    "babel-core": "^6.23.1",
+    "babel-eslint": "^7.1.1",
+    "babel-loader": "^6.3.2",
+    "babel-plugin-istanbul": "^4.0.0",
+    "babel-polyfill": "^6.23.0",
+    "babel-preset-es2015": "^6.22.0",
+    "css-loader": "^0.26.1",
+    "del": "^2.2.2",
+    "es6-shim": "^0.35.3",
+    "extract-text-webpack-plugin": "^2.0.0-rc.3",
+    "html-webpack-plugin": "^2.28.0",
+    "json-loader": "^0.5.4",
+    "postcss-loader": "^1.3.1",
+    "style-loader": "^0.13.1",
+    "uglify-js": "git://github.com/mishoo/UglifyJS2.git#harmony-v2.8.22",
+    "uglifyjs-webpack-plugin": "0.4.3",
+    "webpack": "^2.2.1",
+    "webpack-dev-middleware": "^1.10.1",
+    "webpack-fail-plugin": "^1.0.5",
+    "webpack-hot-middleware": "^2.17.0"
   },
   "dependencies": {
     "basscss": "^8.0.3",
     "basscss-addons": "^1.0.0",
     "basscss-basic": "^1.0.0",
     "normalize.css": "^5.0.0"
+  },
+  "configuratorDependencies": {
   }
 }

--- a/package.json
+++ b/package.json
@@ -59,12 +59,12 @@
     "babel-polyfill": "^6.23.0",
     "babel-preset-es2015": "^6.22.0",
     "css-loader": "^0.26.1",
-    "del": "^2.2.2",
     "es6-shim": "^0.35.3",
     "eslint": "^3.15.0",
-    "eslint-config-xo-space": "^0.15.0",
     "eslint-loader": "^1.6.1",
+    "eslint-config-xo-space": "^0.15.0",
     "eslint-plugin-babel": "^4.0.1",
+    "eslint-plugin-google-camelcase": "0.0.2",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "html-webpack-plugin": "^2.28.0",
     "json-loader": "^0.5.4",
@@ -85,5 +85,17 @@
   },
   "configuratorDependencies": [
     "normalize.css"
-  ]
+  ],
+  "eslintConfig": {
+    "root": true,
+    "env": {
+      "browser": true,
+      "jasmine": true
+    },
+    "extends": [
+      "xo-react/space",
+      "xo-space/esnext"
+    ],
+    "parser": "babel-eslint"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
     "css-loader": "^0.26.1",
     "del": "^2.2.2",
     "es6-shim": "^0.35.3",
+    "eslint": "^3.15.0",
+    "eslint-config-xo-space": "^0.15.0",
+    "eslint-loader": "^1.6.1",
+    "eslint-plugin-babel": "^4.0.1",
     "extract-text-webpack-plugin": "^2.0.0-rc.3",
     "html-webpack-plugin": "^2.28.0",
     "json-loader": "^0.5.4",
@@ -79,6 +83,7 @@
     "basscss-basic": "^1.0.0",
     "normalize.css": "^5.0.0"
   },
-  "configuratorDependencies": {
-  }
+  "configuratorDependencies": [
+    "normalize.css"
+  ]
 }

--- a/tasks/config.js
+++ b/tasks/config.js
@@ -39,6 +39,7 @@ module.exports = {
     css: 'dist/css/',
     img: 'dist/img/',
     configurator: 'dist/configurator',
+    configurator_tmp: '.tmp/configurator'
     uncompiled_css: 'dist/configurator/uncompiledCss'
   },
 };

--- a/tasks/config.js
+++ b/tasks/config.js
@@ -28,7 +28,7 @@ module.exports = {
     css_ignore: ['!css/**/_*.css', '!css/ampstart-base/**/*.css'],
     data: ['*/**/*.json', '!templates/*/data/*.json'],
     img: 'img/**',
-    configurator_app: 'www/configurator'
+    configurator: 'www/configurator/src'
   },
   dest: {
     default: 'dist',
@@ -38,7 +38,7 @@ module.exports = {
     hl_partials: 'dist/hl-partials',
     css: 'dist/css/',
     img: 'dist/img/',
-    configurator_app: 'dist/configurator',
+    configurator: 'dist/configurator',
     uncompiled_css: 'dist/configurator/uncompiledCss'
   },
 };

--- a/tasks/config.js
+++ b/tasks/config.js
@@ -39,7 +39,7 @@ module.exports = {
     css: 'dist/css/',
     img: 'dist/img/',
     configurator: 'dist/configurator',
-    configurator_tmp: '.tmp/configurator'
+    configurator_tmp: '.tmp/configurator',
     uncompiled_css: 'dist/configurator/uncompiledCss'
   },
 };

--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -22,7 +22,7 @@ function validate() {
   return gulp.src([
         `${config.dest.templates}/**/*.html`,
         `!${config.dest.hl_partials}/**/*.html`,
-        `!${config.dest.configurator_app}/**/*.html`,
+        `!${config.dest.configurator}/**/*.html`,
       ])
       .pipe(validator.validate())
       .pipe(validator.format())

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,6 +20,7 @@ const ENV_ALIAS = {
     'prod'
   ],
   DEV: [
+    'development',
     'dev'
   ],
   TEST: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,6 @@ function isNotEnv(envAlias) {
 module.exports = function (webpackEnv) {
   // Set our environemnt
   env = webpackEnv;
-  console.log(env);
   // Create our base webpack configuration
   const webpackConf = {
     module: {
@@ -94,10 +93,11 @@ module.exports = function (webpackEnv) {
   } else if (isEnv(ENV_ALIAS.DEV)) {
     webpackConf.module.loaders.push({
       test: /\.css$/,
-      loaders: ExtractTextPlugin.extract({
-        fallback: 'style-loader',
-        use: 'css-loader?minimize!postcss-loader'
-      })
+      loaders: [
+        'style-loader',
+        'css-loader',
+        'postcss-loader'
+      ]
     });
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,12 @@ module.exports = function (webpackEnv) {
     // Devtool
     webpackConf.devtool = 'source-map';
 
+    // Output
+    webpackConf.output = {
+      path: path.join(process.cwd(), conf.dest.configurator_tmp),
+      filename: 'index.js'
+    };
+
     // Entry
     webpackConf.entry = [
       'webpack/hot/dev-server',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ module.exports = function(webpackEnv) {
       new webpack.NoEmitOnErrorsPlugin(),
       FailPlugin,
       new HtmlWebpackPlugin({
-        template: conf.path.src('index.html')
+        template: `${conf.src.configurator_app}/index.html`
       }),
     ]);
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,7 @@ const FailPlugin = require('webpack-fail-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 
-//Our current environment
+// Our current environment
 let env = {};
 
 // Our environment aliases
@@ -25,19 +25,19 @@ const ENV_ALIAS = {
   TEST: [
     'test'
   ]
-}
+};
 
 /**
 * Function to return if the environment matched the environment alias
 */
 function isEnv(envAlias) {
   // Check for default case
-  if(envAlias === ENV_ALIAS.DEV && (!env || Object.keys(env).length === 0)) {
+  if (envAlias === ENV_ALIAS.DEV && (!env || Object.keys(env).length === 0)) {
     return true;
   }
 
-  return envAlias.some(function(alias) {
-    if(env[alias]) {
+  return envAlias.some(alias => {
+    if (env[alias]) {
       return true;
     }
     return false;
@@ -48,9 +48,7 @@ function isNotEnv(envAlias) {
   return !isEnv(envAlias);
 }
 
-
-module.exports = function(webpackEnv) {
-
+module.exports = function (webpackEnv) {
   // Set our environemnt
   env = webpackEnv;
   console.log(env);
@@ -85,7 +83,7 @@ module.exports = function(webpackEnv) {
   };
 
   // LOADERS
-  if(isEnv(ENV_ALIAS.PROD)) {
+  if (isEnv(ENV_ALIAS.PROD)) {
     webpackConf.module.loaders.push({
       test: /\.css$/,
       loaders: ExtractTextPlugin.extract({
@@ -93,7 +91,7 @@ module.exports = function(webpackEnv) {
         use: 'css-loader?minimize!postcss-loader'
       })
     });
-  } else if(isEnv(ENV_ALIAS.DEV)) {
+  } else if (isEnv(ENV_ALIAS.DEV)) {
     webpackConf.module.loaders.push({
       test: /\.css$/,
       loaders: ExtractTextPlugin.extract({
@@ -103,21 +101,21 @@ module.exports = function(webpackEnv) {
     });
   }
 
-  //PLUGINS
-  if(isNotEnv(ENV_ALIAS.TEST)) {
+  // PLUGINS
+  if (isNotEnv(ENV_ALIAS.TEST)) {
     // Add shared plugins
     webpackConf.plugins =
       webpackConf.plugins.concat([
-      new webpack.optimize.OccurrenceOrderPlugin(),
-      new webpack.NoEmitOnErrorsPlugin(),
-      FailPlugin,
-      new HtmlWebpackPlugin({
-        template: `${conf.src.configurator}/index.html`
-      }),
-    ]);
+        new webpack.optimize.OccurrenceOrderPlugin(),
+        new webpack.NoEmitOnErrorsPlugin(),
+        FailPlugin,
+        new HtmlWebpackPlugin({
+          template: `${conf.src.configurator}/index.html`
+        })
+      ]);
   }
 
-  if(isEnv(ENV_ALIAS.DEV)) {
+  if (isEnv(ENV_ALIAS.DEV)) {
     webpackConf.plugins =
       webpackConf.plugins.concat([
         new webpack.HotModuleReplacementPlugin(),
@@ -128,7 +126,7 @@ module.exports = function(webpackEnv) {
           debug: true
         })
       ]);
-  } else if(isEnv(ENV_ALIAS.PROD)) {
+  } else if (isEnv(ENV_ALIAS.PROD)) {
     webpackConf.plugins =
       webpackConf.plugins.concat([
         new webpack.DefinePlugin({
@@ -146,7 +144,7 @@ module.exports = function(webpackEnv) {
           }
         })
       ]);
-  } else if(isEnv(ENV_ALIAS.TEST)) {
+  } else if (isEnv(ENV_ALIAS.TEST)) {
     webpackConf.plugins =
       webpackConf.plugins.concat([
         new webpack.LoaderOptionsPlugin({
@@ -156,41 +154,41 @@ module.exports = function(webpackEnv) {
       ]);
   }
 
-  //DEVTOOL
-  if(isNotEnv(ENV_ALIAS.PROD)) {
+  // DEVTOOL
+  if (isNotEnv(ENV_ALIAS.PROD)) {
     webpackConf.devtool = 'source-map';
   }
 
-  //OUTPUT
-  if(isEnv(ENV_ALIAS.DEV)) {
+  // OUTPUT
+  if (isEnv(ENV_ALIAS.DEV)) {
     webpackConf.output = {
       path: path.join(process.cwd(), conf.dest.configurator_tmp),
       filename: 'index.js'
-    }
-  } else if(isEnv(ENV_ALIAS.PROD)) {
+    };
+  } else if (isEnv(ENV_ALIAS.PROD)) {
     webpackConf.output = {
       path: path.join(process.cwd(), conf.dest.configurator),
       filename: '[name]-[hash].js'
-    }
+    };
   }
 
-  //ENTRY
-  if(isEnv(ENV_ALIAS.DEV)) {
+  // ENTRY
+  if (isEnv(ENV_ALIAS.DEV)) {
     webpackConf.entry = [
       'webpack/hot/dev-server',
       'webpack-hot-middleware/client',
       `./${conf.src.configurator}/index`
-    ]
-  } else if(isEnv(ENV_ALIAS.PROD)) {
+    ];
+  } else if (isEnv(ENV_ALIAS.PROD)) {
     webpackConf.entry = {
       app: `./${conf.src.configurator}/index`,
       vendor: pkg.configuratorDependencies
-    }
+    };
   }
 
-  //EXTERNALS
-  if(isEnv(ENV_ALIAS.TEST)) {
-    webpackConf.externals = {}
+  // EXTERNALS
+  if (isEnv(ENV_ALIAS.TEST)) {
+    webpackConf.externals = {};
   }
 
   return webpackConf;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,12 +164,12 @@ module.exports = function(webpackEnv) {
   //OUTPUT
   if(isENV(ENV_ALIAS.DEV)) {
     webpackConf.module.output = {
-      path: path.join(process.cwd(), conf.paths.tmp),
+      path: path.join(process.cwd(), conf.dist.configurator_tmp),
       filename: 'index.js'
     }
   } else if(isENV(ENV_ALIAS.PROD)) {
     webpackConf.module.output = {
-      path: path.join(process.cwd(), conf.paths.dist),
+      path: path.join(process.cwd(), conf.dist.configurator),
       filename: '[name]-[hash].js'
     }
   }
@@ -179,11 +179,11 @@ module.exports = function(webpackEnv) {
     webpackConf.module.entry = [
       'webpack/hot/dev-server',
       'webpack-hot-middleware/client',
-      `./${conf.configurator_app}/index`
+      `./${conf.src.configurator}/index`
     ]
   } else if(isENV(ENV_ALIAS.PROD)) {
     webpackConf.module.entry = {
-      app: `./${conf.configurator_app}/index`,
+      app: `./${conf.src.configurator}/index`,
       vendor: pkg.configuratorDependencies
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,6 @@
 const webpack = require('webpack');
-const conf = require('tasks/config.js');
-const pkg = require('package.json');
+const conf = require('./tasks/config.js');
+const pkg = require('./package.json');
 const path = require('path');
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
@@ -11,7 +11,7 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const autoprefixer = require('autoprefixer');
 
 //Our current environment
-const env = {};
+let env = {};
 
 // Our environment aliases
 const ENV_ALIAS = {
@@ -53,7 +53,7 @@ module.exports = function(webpackEnv) {
 
   // Set our environemnt
   env = webpackEnv;
-
+  console.log(env);
   // Create our base webpack configuration
   const webpackConf = {
     module: {
@@ -93,7 +93,7 @@ module.exports = function(webpackEnv) {
         use: 'css-loader?minimize!postcss-loader'
       })
     });
-  } else if(isENV(ENV_ALIAS.DEV)) {
+  } else if(isEnv(ENV_ALIAS.DEV)) {
     webpackConf.module.loaders.push({
       test: /\.css$/,
       loaders: ExtractTextPlugin.extract({
@@ -106,8 +106,8 @@ module.exports = function(webpackEnv) {
   //PLUGINS
   if(isNotEnv(ENV_ALIAS.TEST)) {
     // Add shared plugins
-    webpackConf.module.plugins =
-      webpackConf.module.plugins.concat([
+    webpackConf.plugins =
+      webpackConf.plugins.concat([
       new webpack.optimize.OccurrenceOrderPlugin(),
       new webpack.NoEmitOnErrorsPlugin(),
       FailPlugin,
@@ -118,8 +118,8 @@ module.exports = function(webpackEnv) {
   }
 
   if(isEnv(ENV_ALIAS.DEV)) {
-    webpackConf.module.plugins =
-      webpackConf.module.plugins.concat([
+    webpackConf.plugins =
+      webpackConf.plugins.concat([
         new webpack.HotModuleReplacementPlugin(),
         new webpack.LoaderOptionsPlugin({
           options: {
@@ -129,8 +129,8 @@ module.exports = function(webpackEnv) {
         })
       ]);
   } else if(isEnv(ENV_ALIAS.PROD)) {
-    webpackConf.module.plugins =
-      webpackConf.module.plugins.concat([
+    webpackConf.plugins =
+      webpackConf.plugins.concat([
         new webpack.DefinePlugin({
           'process.env.NODE_ENV': '"production"'
         }),
@@ -147,8 +147,8 @@ module.exports = function(webpackEnv) {
         })
       ]);
   } else if(isEnv(ENV_ALIAS.TEST)) {
-    webpackConf.module.plugins =
-      webpackConf.module.plugins.concat([
+    webpackConf.plugins =
+      webpackConf.plugins.concat([
         new webpack.LoaderOptionsPlugin({
           options: {},
           debug: true
@@ -158,31 +158,31 @@ module.exports = function(webpackEnv) {
 
   //DEVTOOL
   if(isNotEnv(ENV_ALIAS.PROD)) {
-    webpackConf.module.devtool = 'source-map';
+    webpackConf.devtool = 'source-map';
   }
 
   //OUTPUT
-  if(isENV(ENV_ALIAS.DEV)) {
-    webpackConf.module.output = {
+  if(isEnv(ENV_ALIAS.DEV)) {
+    webpackConf.output = {
       path: path.join(process.cwd(), conf.dist.configurator_tmp),
       filename: 'index.js'
     }
   } else if(isENV(ENV_ALIAS.PROD)) {
-    webpackConf.module.output = {
+    webpackConf.output = {
       path: path.join(process.cwd(), conf.dist.configurator),
       filename: '[name]-[hash].js'
     }
   }
 
   //ENTRY
-  if(isENV(ENV_ALIAS.DEV)) {
-    webpackConf.module.entry = [
+  if(isEnv(ENV_ALIAS.DEV)) {
+    webpackConf.entry = [
       'webpack/hot/dev-server',
       'webpack-hot-middleware/client',
       `./${conf.src.configurator}/index`
     ]
   } else if(isENV(ENV_ALIAS.PROD)) {
-    webpackConf.module.entry = {
+    webpackConf.entry = {
       app: `./${conf.src.configurator}/index`,
       vendor: pkg.configuratorDependencies
     }
@@ -190,7 +190,7 @@ module.exports = function(webpackEnv) {
 
   //EXTERNALS
   if(isENV(ENV_ALIAS.TEST)) {
-    webpackConf.module.externals = {}
+    webpackConf.externals = {}
   }
 
   return webpackConf;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,7 @@ const ENV_ALIAS = {
 */
 function isEnv(envAlias) {
   // Check for default case
-  if(envAlias === ENV_ALIAS.DEV && Object.keys(env).length === 0) {
+  if(envAlias === ENV_ALIAS.DEV && (!env || Object.keys(env).length === 0)) {
     return true;
   }
 
@@ -112,7 +112,7 @@ module.exports = function(webpackEnv) {
       new webpack.NoEmitOnErrorsPlugin(),
       FailPlugin,
       new HtmlWebpackPlugin({
-        template: `${conf.configurator_app}/index.html`
+        template: `${conf.src.configurator}/index.html`
       }),
     ]);
   }
@@ -164,12 +164,12 @@ module.exports = function(webpackEnv) {
   //OUTPUT
   if(isEnv(ENV_ALIAS.DEV)) {
     webpackConf.output = {
-      path: path.join(process.cwd(), conf.dist.configurator_tmp),
+      path: path.join(process.cwd(), conf.dest.configurator_tmp),
       filename: 'index.js'
     }
-  } else if(isENV(ENV_ALIAS.PROD)) {
+  } else if(isEnv(ENV_ALIAS.PROD)) {
     webpackConf.output = {
-      path: path.join(process.cwd(), conf.dist.configurator),
+      path: path.join(process.cwd(), conf.dest.configurator),
       filename: '[name]-[hash].js'
     }
   }
@@ -181,7 +181,7 @@ module.exports = function(webpackEnv) {
       'webpack-hot-middleware/client',
       `./${conf.src.configurator}/index`
     ]
-  } else if(isENV(ENV_ALIAS.PROD)) {
+  } else if(isEnv(ENV_ALIAS.PROD)) {
     webpackConf.entry = {
       app: `./${conf.src.configurator}/index`,
       vendor: pkg.configuratorDependencies
@@ -189,7 +189,7 @@ module.exports = function(webpackEnv) {
   }
 
   //EXTERNALS
-  if(isENV(ENV_ALIAS.TEST)) {
+  if(isEnv(ENV_ALIAS.TEST)) {
     webpackConf.externals = {}
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,7 +112,7 @@ module.exports = function(webpackEnv) {
       new webpack.NoEmitOnErrorsPlugin(),
       FailPlugin,
       new HtmlWebpackPlugin({
-        template: `${conf.src.configurator_app}/index.html`
+        template: `${conf.configurator_app}/index.html`
       }),
     ]);
   }
@@ -179,11 +179,11 @@ module.exports = function(webpackEnv) {
     webpackConf.module.entry = [
       'webpack/hot/dev-server',
       'webpack-hot-middleware/client',
-      `./${conf.path.src('index')}`
+      `./${conf.configurator_app}/index`
     ]
   } else if(isENV(ENV_ALIAS.PROD)) {
     webpackConf.module.entry = {
-      app: `./${conf.path.src('index')}`,
+      app: `./${conf.configurator_app}/index`,
       vendor: pkg.configuratorDependencies
     }
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,197 @@
+const webpack = require('webpack');
+const conf = require('tasks/config.js');
+const pkg = require('package.json');
+const path = require('path');
+
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+// Doing a webpack hack for es6: https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/33
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const FailPlugin = require('webpack-fail-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const autoprefixer = require('autoprefixer');
+
+//Our current environment
+const env = {};
+
+// Our environment aliases
+const ENV_ALIAS = {
+  PROD: [
+    'production',
+    'prod'
+  ],
+  DEV: [
+    'dev'
+  ],
+  TEST: [
+    'test'
+  ]
+}
+
+/**
+* Function to return if the environment matched the environment alias
+*/
+function isEnv(envAlias) {
+  // Check for default case
+  if(envAlias === ENV_ALIAS.DEV && Object.keys(env).length === 0) {
+    return true;
+  }
+
+  return envAlias.some(function(alias) {
+    if(env[alias]) {
+      return true;
+    }
+    return false;
+  });
+}
+
+function isNotEnv(envAlias) {
+  return !isEnv(envAlias);
+}
+
+
+module.exports = function(webpackEnv) {
+
+  // Set our environemnt
+  env = webpackEnv;
+
+  // Create our base webpack configuration
+  const webpackConf = {
+    module: {
+      loaders: [
+        {
+          test: /\.json$/,
+          loaders: [
+            'json-loader'
+          ]
+        },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loader: 'eslint-loader',
+          enforce: 'pre'
+        },
+        {
+          test: /\.js$/,
+          exclude: /node_modules/,
+          loaders: [
+            'babel-loader'
+          ]
+        }
+      ]
+    },
+    plugins: [],
+    output: {},
+    entry: []
+  };
+
+  // LOADERS
+  if(isEnv(ENV_ALIAS.PROD)) {
+    webpackConf.module.loaders.push({
+      test: /\.css$/,
+      loaders: ExtractTextPlugin.extract({
+        fallback: 'style-loader',
+        use: 'css-loader?minimize!postcss-loader'
+      })
+    });
+  } else if(isENV(ENV_ALIAS.DEV)) {
+    webpackConf.module.loaders.push({
+      test: /\.css$/,
+      loaders: ExtractTextPlugin.extract({
+        fallback: 'style-loader',
+        use: 'css-loader?minimize!postcss-loader'
+      })
+    });
+  }
+
+  //PLUGINS
+  if(isNotEnv(ENV_ALIAS.TEST)) {
+    // Add shared plugins
+    webpackConf.module.plugins =
+      webpackConf.module.plugins.concat([
+      new webpack.optimize.OccurrenceOrderPlugin(),
+      new webpack.NoEmitOnErrorsPlugin(),
+      FailPlugin,
+      new HtmlWebpackPlugin({
+        template: conf.path.src('index.html')
+      }),
+    ]);
+  }
+
+  if(isEnv(ENV_ALIAS.DEV)) {
+    webpackConf.module.plugins =
+      webpackConf.module.plugins.concat([
+        new webpack.HotModuleReplacementPlugin(),
+        new webpack.LoaderOptionsPlugin({
+          options: {
+            postcss: () => [autoprefixer]
+          },
+          debug: true
+        })
+      ]);
+  } else if(isEnv(ENV_ALIAS.PROD)) {
+    webpackConf.module.plugins =
+      webpackConf.module.plugins.concat([
+        new webpack.DefinePlugin({
+          'process.env.NODE_ENV': '"production"'
+        }),
+        new UglifyJsPlugin({
+          output: {comments: false},
+          compress: {unused: true, dead_code: true, warnings: false} // eslint-disable-line camelcase
+        }),
+        new ExtractTextPlugin('index-[contenthash].css'),
+        new webpack.optimize.CommonsChunkPlugin({name: 'vendor'}),
+        new webpack.LoaderOptionsPlugin({
+          options: {
+            postcss: () => [autoprefixer]
+          }
+        })
+      ]);
+  } else if(isEnv(ENV_ALIAS.TEST)) {
+    webpackConf.module.plugins =
+      webpackConf.module.plugins.concat([
+        new webpack.LoaderOptionsPlugin({
+          options: {},
+          debug: true
+        })
+      ]);
+  }
+
+  //DEVTOOL
+  if(isNotEnv(ENV_ALIAS.PROD)) {
+    webpackConf.module.devtool = 'source-map';
+  }
+
+  //OUTPUT
+  if(isENV(ENV_ALIAS.DEV)) {
+    webpackConf.module.output = {
+      path: path.join(process.cwd(), conf.paths.tmp),
+      filename: 'index.js'
+    }
+  } else if(isENV(ENV_ALIAS.PROD)) {
+    webpackConf.module.output = {
+      path: path.join(process.cwd(), conf.paths.dist),
+      filename: '[name]-[hash].js'
+    }
+  }
+
+  //ENTRY
+  if(isENV(ENV_ALIAS.DEV)) {
+    webpackConf.module.entry = [
+      'webpack/hot/dev-server',
+      'webpack-hot-middleware/client',
+      `./${conf.path.src('index')}`
+    ]
+  } else if(isENV(ENV_ALIAS.PROD)) {
+    webpackConf.module.entry = {
+      app: `./${conf.path.src('index')}`,
+      vendor: pkg.configuratorDependencies
+    }
+  }
+
+  //EXTERNALS
+  if(isENV(ENV_ALIAS.TEST)) {
+    webpackConf.module.externals = {}
+  }
+
+  return webpackConf;
+};

--- a/www/configurator/src/app/hello.js
+++ b/www/configurator/src/app/hello.js
@@ -1,4 +1,5 @@
 export function hello() {
   console.log(document);
-  document.getElementById('hello-test').textContent = 'Hello, from Amp Start hello.js!';
+  document.getElementById('hello-test')
+    .textContent = 'Hello, from Amp Start hello.js!';
 }


### PR DESCRIPTION
This creates the web pack configuration for the AMP Start configurator. This supports the enviornments `dev` and `prod`. This also introduces some linting to the project, as it is used for the webpack process to stop unlinted builds from running. Also, confirmed that files are building to the correct directories, and dist files for configurator are located under `dist/configurator`

# Screenshots

**Please note:**
I have `webpack` alaised to `./node_modules/.bin/webpack --config webpack.config.js`

`dev`

<img width="1403" alt="screen shot 2017-08-07 at 3 11 15 pm" src="https://user-images.githubusercontent.com/1448289/29047865-b15fb2fa-7b82-11e7-8224-390055dcf4fc.png">

`prod`

<img width="1394" alt="screen shot 2017-08-07 at 3 11 40 pm" src="https://user-images.githubusercontent.com/1448289/29047868-bffd306c-7b82-11e7-9724-a32764e34d80.png">
