### PR TITLE
Added the gulp-util plugin to the package.json

### DIFF
--- a/tools/gulp-replace-important/package.json
+++ b/tools/gulp-replace-important/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-replace-important",
-  "version": "1.0.1-alpha",
+  "version": "1.0.2-alpha",
   "description": "Gulp Wrapper for the replace-important module",
   "main": "index.js",
   "scripts": {

--- a/tools/gulp-replace-important/package.json
+++ b/tools/gulp-replace-important/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/ampproject/ampstart#readme",
   "dependencies": {
+    "gulp-util": "^3.0.8",
     "replace-important": "1.0.0-alpha",
     "through2": "^2.0.3"
   },


### PR DESCRIPTION
Forgot to `npm-install --save` the `gulp-util` package. Went uncaught since it was in the parent ampstart /nodemodules folder.
