### PR TITLE
Fixed NPM Warnings and gulp default

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -195,7 +195,7 @@ gulp.task('watch:dev', 'watch stuff, (more) minimal watching for development, wi
       });
 });
 
-gulp.task('default', ['watch:dev']);
+gulp.task('default', ['serve']);
 
 gulp.task('posthtml', 'build kickstart files', function() {
   const plugins = [
@@ -231,7 +231,7 @@ gulp.task('postcss', 'build postcss files', function() {
       .pipe(gulp.dest(config.dest.css))
 });
 
-gulp.task('serve', 'Host a livereloading development webserver for amp start', ['watch:www', 'configurator:watch'], function() {
+gulp.task('serve', 'Host a livereloading development webserver for amp start', ['watch:dev', 'configurator:watch'], function() {
   gulp.src(config.dest.default).pipe(server({
     livereload: true,
     host: '0.0.0.0',

--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-dev-server": "^2.7.1",
-    "webpack-fail-plugin": "^1.0.5",
     "webpack-hot-middleware": "^2.17.0"
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 // Doing a webpack hack for es6: https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/33
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
-const FailPlugin = require('webpack-fail-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const autoprefixer = require('autoprefixer');
@@ -90,7 +89,6 @@ module.exports = function (webpackEnv) {
       webpackConf.plugins.concat([
         new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.NoEmitOnErrorsPlugin(),
-        FailPlugin,
         new HtmlWebpackPlugin({
           template: `${conf.src.configurator}/index.html`
         }),
@@ -141,7 +139,6 @@ module.exports = function (webpackEnv) {
       webpackConf.plugins.concat([
         new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.NoEmitOnErrorsPlugin(),
-        FailPlugin,
         new HtmlWebpackPlugin({
           template: `${conf.src.configurator}/index.html`
         }),


### PR DESCRIPTION
* Removes the deprecated web pack plugin: https://www.npmjs.com/package/webpack-fail-plugin
* `gulp serve` now runs `gulp watch:dev`, and `gulp` default is `gulp serve`

# Example
**No more npm WARN**, Would need to delete node modules directory, then npm install, and then npm install again
![screen shot 2017-08-16 at 11 33 14 am](https://user-images.githubusercontent.com/1448289/29379269-c58e2c34-8276-11e7-8190-18bc51e50bda.png)
