### PR TITLE
[Configurator] Added Web Workers to Support CSS Transpilation

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "webpack": "^2.2.1",
     "webpack-dev-middleware": "^1.10.1",
     "webpack-dev-server": "^2.7.1",
-    "webpack-hot-middleware": "^2.17.0"
+    "webpack-hot-middleware": "^2.17.0",
+    "worker-loader": "^0.8.1"
   },
   "dependencies": {
     "basscss": "^8.0.3",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -95,7 +95,13 @@ module.exports = function (webpackEnv) {
         new webpack.HotModuleReplacementPlugin(),
         new webpack.LoaderOptionsPlugin({
           options: {
-            postcss: () => [autoprefixer]
+            postcss: () => [autoprefixer],
+            worker: {
+              output: {
+                filename: 'hash.worker.js',
+                chunkFilename: '[id].hash.worker.js'
+              }
+            }
           },
           debug: true
         }),
@@ -153,7 +159,13 @@ module.exports = function (webpackEnv) {
         new webpack.optimize.CommonsChunkPlugin({name: 'vendor'}),
         new webpack.LoaderOptionsPlugin({
           options: {
-            postcss: () => [autoprefixer]
+            postcss: () => [autoprefixer],
+            worker: {
+              output: {
+                filename: 'hash.worker.js',
+                chunkFilename: '[id].hash.worker.js'
+              }
+            }
           }
         })
       ]);
@@ -180,7 +192,14 @@ module.exports = function (webpackEnv) {
     webpackConf.plugins =
       webpackConf.plugins.concat([
         new webpack.LoaderOptionsPlugin({
-          options: {},
+          options: {
+            worker: {
+              output: {
+                filename: 'hash.worker.js',
+                chunkFilename: '[id].hash.worker.js'
+              }
+            }
+          },
           debug: true
         })
       ]);

--- a/www/configurator/src/app/css-transpiler/css-transpiler.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.js
@@ -21,6 +21,10 @@
 
 const postcss = require('postcss');
 const customProperties = require('postcss-custom-properties');
+// Grab the Worker Using Webpack
+// https://github.com/webpack/webpack/tree/master/examples/web-worker
+// https://github.com/webpack-contrib/worker-loader
+const Worker = require('worker-loader!./css-transpiler.worker');
 
 class CssTranspiler {
   /**
@@ -39,6 +43,11 @@ class CssTranspiler {
    * @returns {string} - the newly transpiled page css with varibale values
    */
   getCssWithVars(passedCssVars) {
+    // Testing the webworker
+    // eslint-disable-next-line
+    const worker = new Worker;
+    worker.postMessage('b');
+
     // Only assign variables that exist in both, and set to the current value
     const cssVars = Object.assign({}, this.templateCssVars);
     Object.keys(passedCssVars).forEach(cssVarKey => {
@@ -46,6 +55,8 @@ class CssTranspiler {
         cssVars[cssVarKey].current = passedCssVars[cssVarKey];
       }
     });
+
+    // Add the onmessage here
 
     // Append the new vars to the end of our template css
     let cssWithAppendedVars = `${this.templateCss.slice(0)} :root {`;

--- a/www/configurator/src/app/css-transpiler/css-transpiler.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.js
@@ -44,7 +44,7 @@ class CssTranspiler {
    * Function to retranspile page css with new css vars, using postcss
    * @param {Object} passedCssVars - Json object, where the key represents the css variable to be modified,
    *    and the value represents the variables new value
-   * @returns {string} - the newly transpiled page css with varibale values
+   * @returns {Promise} - Will resolve with the response from a webworker, containing the newly transpiled css
    */
   getCssWithVars(passedCssVars) {
     // First check if we have a worker, and if it resolved

--- a/www/configurator/src/app/css-transpiler/css-transpiler.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.js
@@ -22,7 +22,7 @@
 // Grab the Worker Using Webpack
 // https://github.com/webpack/webpack/tree/master/examples/web-worker
 // https://github.com/webpack-contrib/worker-loader
-const Worker = require('worker-loader!./css-transpiler.worker');
+const CssTranspilerWorker = require('worker-loader!./css-transpiler.worker');
 
 class CssTranspiler {
   /**
@@ -33,7 +33,7 @@ class CssTranspiler {
     this.templateCss = css;
     this.templateCssVars = cssVars;
     this.asyncPostcssWorker = {
-      worker: new Worker(),
+      worker: new CssTranspilerWorker(),
       didRespond: true
     };
   }
@@ -50,7 +50,7 @@ class CssTranspiler {
       // Terminate the worker, and recreate it
       this.asyncPostcssWorker.worker.terminate();
       this.asyncPostcssWorker = {
-        worker: new Worker(),
+        worker: new CssTranspilerWorker(),
         didRespond: false
       };
     } else {

--- a/www/configurator/src/app/css-transpiler/css-transpiler.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.js
@@ -57,6 +57,7 @@ class CssTranspiler {
     });
 
     // Add the onmessage here
+    worker.postMessage(cssVars);
 
     // Append the new vars to the end of our template css
     let cssWithAppendedVars = `${this.templateCss.slice(0)} :root {`;

--- a/www/configurator/src/app/css-transpiler/css-transpiler.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.js
@@ -73,10 +73,10 @@ class CssTranspiler {
     return new Promise((resolve, reject) => {
       this.asyncPostcssWorker.worker.onmessage = event => {
         this.asyncPostcssWorker.didRespond = true;
-        if (event) {
+        if (event && !(event.data instanceof Error)) {
           resolve(event.data);
         } else {
-          reject();
+          reject(event.data);
         }
       };
     });

--- a/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 /**
   * @fileoverview Web worker for the CssTranspiler Class, to handle css transpilation.
 	* 		Simply responds to messages containing the template CSS, and css vars, and responds with the newly transpiled css.
@@ -8,20 +6,40 @@
 const postcss = require('postcss');
 const customProperties = require('postcss-custom-properties');
 
-onmessage = function(event) {
+// Worker definitions to not follow normal es6 eslint syntax, declaring here
+/* global onmessage:true */
+/* exported onmessage */
+onmessage = function (event) {
+  // Check that we have a valid message
+  if (!event.data ||
+    !event.data.templateCss ||
+    !event.data.cssVars) {
+    postMessage(false);
+    return;
+  }
 
 	// Obtain the templateCss and cssvars from event
-	const templateCss = event.data.templateCss;
-	const cssVars = event.data.cssVars;
+  const templateCss = event.data.templateCss;
+  const cssVars = event.data.cssVars;
 
 	// Append the new vars to the end of our template css
-	let cssWithAppendedVars = `${templateCss} \n:root {`;
-	Object.keys(cssVars).forEach(cssVarKey => {
-		cssWithAppendedVars += `\n${cssVarKey}: ${cssVars[cssVarKey].current || cssVars[cssVarKey].value};`;
-	});
-	cssWithAppendedVars += '\n}';
+  let cssWithAppendedVars = `${templateCss} \n:root {`;
+  Object.keys(cssVars).forEach(cssVarKey => {
+    // Ensure we have a valid CSS Variable
+    if (cssVars[cssVarKey]) {
+      if (cssVars[cssVarKey].current || cssVars[cssVarKey].value) {
+        cssWithAppendedVars +=
+          `\n${cssVarKey}: ${cssVars[cssVarKey].current || cssVars[cssVarKey].value};`;
+      }
+    }
+  });
+  cssWithAppendedVars += '\n}';
 
-	// Transpile the CSS with the appended variables
-	postMessage(postcss().use(customProperties()).process(cssWithAppendedVars).css);
-}
-/* eslint-enable */
+  // Transpile the CSS with the appended variables
+  postcss().use(customProperties()).process(cssWithAppendedVars).then(result => {
+    postMessage(result.css);
+  }).catch(error => {
+    console.error(error);
+    postMessage(false);
+  });
+};

--- a/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
@@ -1,5 +1,4 @@
 /* eslint-disable */
-
 const postcss = require('postcss');
 const customProperties = require('postcss-custom-properties');
 
@@ -10,11 +9,11 @@ onmessage = function(event) {
 	const cssVars = event.data.cssVars;
 
 	// Append the new vars to the end of our template css
-	let cssWithAppendedVars = `${templateCss} :root {`;
+	let cssWithAppendedVars = `${templateCss} \n:root {`;
 	Object.keys(cssVars).forEach(cssVarKey => {
-		cssWithAppendedVars += `\n${cssVarKey}: ${[cssVarKey].current || [cssVarKey].value};`;
+		cssWithAppendedVars += `\n${cssVarKey}: ${cssVars[cssVarKey].current || cssVars[cssVarKey].value};`;
 	});
-	cssWithAppendedVars += '}';
+	cssWithAppendedVars += '\n}';
 
 	// Transpile the CSS with the appended variables
 	postMessage(postcss().use(customProperties()).process(cssWithAppendedVars).css);

--- a/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
@@ -1,4 +1,10 @@
 /* eslint-disable */
+
+/**
+  * @fileoverview Web worker for the CssTranspiler Class, to handle css transpilation.
+	* 		Simply responds to messages containing the template CSS, and css vars, and responds with the newly transpiled css.
+  */
+
 const postcss = require('postcss');
 const customProperties = require('postcss-custom-properties');
 

--- a/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
@@ -39,7 +39,6 @@ onmessage = function (event) {
   postcss().use(customProperties()).process(cssWithAppendedVars).then(result => {
     postMessage(result.css);
   }).catch(error => {
-    console.error(error);
-    postMessage(false);
+    postMessage(error);
   });
 };

--- a/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
@@ -1,0 +1,19 @@
+const postcss = require('postcss');
+const customProperties = require('postcss-custom-properties');
+
+/* eslint-disable */
+onmessage = function(event) {
+	console.log(event);
+	console.log(postcss);
+
+	// Append the new vars to the end of our template css
+	let cssWithAppendedVars = `${this.templateCss.slice(0)} :root {`;
+	Object.keys(cssVars).forEach(cssVarKey => {
+		cssWithAppendedVars += `\n${cssVarKey}: ${cssVars[cssVarKey].current || cssVars[cssVarKey].value};`;
+	});
+	cssWithAppendedVars += '}';
+
+	// Transpile the CSS with the appended variables
+	return postcss().use(customProperties()).process(cssWithAppendedVars).css;
+}
+/* eslint-enable */

--- a/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
+++ b/www/configurator/src/app/css-transpiler/css-transpiler.worker.js
@@ -1,19 +1,22 @@
+/* eslint-disable */
+
 const postcss = require('postcss');
 const customProperties = require('postcss-custom-properties');
 
-/* eslint-disable */
 onmessage = function(event) {
-	console.log(event);
-	console.log(postcss);
+
+	// Obtain the templateCss and cssvars from event
+	const templateCss = event.data.templateCss;
+	const cssVars = event.data.cssVars;
 
 	// Append the new vars to the end of our template css
-	let cssWithAppendedVars = `${this.templateCss.slice(0)} :root {`;
+	let cssWithAppendedVars = `${templateCss} :root {`;
 	Object.keys(cssVars).forEach(cssVarKey => {
-		cssWithAppendedVars += `\n${cssVarKey}: ${cssVars[cssVarKey].current || cssVars[cssVarKey].value};`;
+		cssWithAppendedVars += `\n${cssVarKey}: ${[cssVarKey].current || [cssVarKey].value};`;
 	});
 	cssWithAppendedVars += '}';
 
 	// Transpile the CSS with the appended variables
-	return postcss().use(customProperties()).process(cssWithAppendedVars).css;
+	postMessage(postcss().use(customProperties()).process(cssWithAppendedVars).css);
 }
 /* eslint-enable */

--- a/www/configurator/src/index.js
+++ b/www/configurator/src/index.js
@@ -92,5 +92,9 @@ Promise.all(configuratorInit).then(responses => {
 function handleHashChange_() {
   cssTranspiler.getCssWithVars(getUrlCssVars()).then(updatedStyles => {
     iframeManager.setStyle(updatedStyles);
+  }).catch(() => {
+    // Set styles back to the initial styles
+    // TODO (torch2424 && camelburrito) - Talk offline to decide how to display transpilation error to user
+    iframeManager.setStyle(cssTranspiler.templateCss);
   });
 }

--- a/www/configurator/src/index.js
+++ b/www/configurator/src/index.js
@@ -77,11 +77,12 @@ Promise.all(configuratorInit).then(responses => {
   cssTranspiler = new CssTranspiler(responses[1], responses[0]);
 
   // Apply initial styles
-  const initialStyles = cssTranspiler.getCssWithVars(getUrlCssVars());
-  iframeManager.setStyle(initialStyles);
+  cssTranspiler.getCssWithVars(getUrlCssVars()).then(initialStyles => {
+    iframeManager.setStyle(initialStyles);
 
-  // Listen to has change events on the page
-  window.addEventListener('hashchange', handleHashChange_);
+    // Listen to has change events on the page
+    window.addEventListener('hashchange', handleHashChange_);
+  });
 });
 
 /**
@@ -89,6 +90,7 @@ Promise.all(configuratorInit).then(responses => {
  *    Also, this will simply get the latest URL params, pass them to the transpiler, and set the styles in the iframe manager.
  */
 function handleHashChange_() {
-  const updatedStyles = cssTranspiler.getCssWithVars(getUrlCssVars());
-  iframeManager.setStyle(updatedStyles);
+  cssTranspiler.getCssWithVars(getUrlCssVars()).then(updatedStyles => {
+    iframeManager.setStyle(updatedStyles);
+  });
 }

--- a/www/configurator/src/index.js
+++ b/www/configurator/src/index.js
@@ -92,9 +92,8 @@ Promise.all(configuratorInit).then(responses => {
 function handleHashChange_() {
   cssTranspiler.getCssWithVars(getUrlCssVars()).then(updatedStyles => {
     iframeManager.setStyle(updatedStyles);
-  }).catch(() => {
-    // Set styles back to the initial styles
-    // TODO (torch2424 && camelburrito) - Talk offline to decide how to display transpilation error to user
-    iframeManager.setStyle(cssTranspiler.templateCss);
+  }).catch(error => {
+    // Don't set the styles, log the error
+    console.error(error);
   });
 }


### PR DESCRIPTION
* Offloaded postcss transpilation into a webworker, and updated the `CssTranspiler.getCssWithVars()` to return a promise accordingly.

Also, I profiled switching variables very fast and quickly, and handled the operation fine. No more than 10% CPU usage, and ~170MB of Ram under load, ~9MB idle (For comparison, Gmail uses ~130MB idle).

# Screenshot

![screen shot 2017-08-16 at 5 16 23 pm](https://user-images.githubusercontent.com/1448289/29390856-03af5d72-82a8-11e7-83a0-a506a99cc1a0.png)
