### PR TITLE
[WIP] Amp Start Configurator Container

### DIFF
--- a/css/CSS_SIZES.md
+++ b/css/CSS_SIZES.md
@@ -11,7 +11,7 @@
 | templates/themes_2/page.css   | 24402                | 24.40 KB |
 | templates/thescenic/page.css  | 23921                | 23.92 KB |
 | www/components/page.css       | 22712                | 22.71 KB |
-| www/configurator/page.css     | 17913                | 17.91 KB |
+| www/configurator/page.css     | 17969                | 17.97 KB |
 | www/getstarted/page.css       | 17945                | 17.95 KB |
 | www/howitworks/page.css       | 17945                | 17.95 KB |
 | www/index/page.css            | 22125                | 22.13 KB |

--- a/css/CSS_SIZES.md
+++ b/css/CSS_SIZES.md
@@ -11,6 +11,7 @@
 | templates/themes_2/page.css   | 24402                | 24.40 KB |
 | templates/thescenic/page.css  | 23921                | 23.92 KB |
 | www/components/page.css       | 22712                | 22.71 KB |
+| www/configurator/page.css     | 17913                | 17.91 KB |
 | www/getstarted/page.css       | 17945                | 17.95 KB |
 | www/howitworks/page.css       | 17945                | 17.95 KB |
 | www/index/page.css            | 22125                | 22.13 KB |

--- a/css/www/configurator/page.css
+++ b/css/www/configurator/page.css
@@ -1,0 +1,17 @@
+/**
+ * Copyright 2017 The AMP Start Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+@import '../shared';

--- a/css/www/configurator/page.css
+++ b/css/www/configurator/page.css
@@ -15,3 +15,9 @@
  */
 
 @import '../shared';
+
+.configurator__iframe {
+  border: 2px solid black;
+  margin: 10px;
+  
+}

--- a/tasks/configurator.js
+++ b/tasks/configurator.js
@@ -166,7 +166,9 @@ function cssVarsJson() {
 
 // Define our gulp tasks
 gulp.task('configurator', 'Runs the default, configurator:build for prod deployment', ['configurator:build']);
-gulp.task('configurator:build', 'Builds the configurator for deployment, analyzes the templates css, converts to json, and then builds the configurator webapp', ['configurator:css', 'configurator:json', 'configurator:webpack']);
+gulp.task('configurator:build', 'Builds the configurator for deployment, analyzes the templates css, converts to json, and then builds the configurator webapp', function(cb) {
+  runSequence(['configurator:css', 'configurator:webpack'], 'configurator:json', cb);
+});
 gulp.task('configurator:webpack', 'Builds only the configurator webapp using webpack, and passing the prod environment', configuratorWebpackProd);
 gulp.task('configurator:serve', 'Opens a dev server at localhost:8080 for the configurator, and watches/livreloads on changes. Port can be changed with --port="PORT_NUMBER_HERE"', configuratorServe);
 gulp.task('configurator:watch', 'Watches the configurator src directory, and runs prod webpack builds on changes. Useful for eveloping both the configurator and ampstart', configuratorWatchProd);

--- a/www/configurator.html
+++ b/www/configurator.html
@@ -30,6 +30,18 @@ limitations under the License.
     <aside class="col-2 xs-hide"></aside>
     <article class="flex-auto col-8">
       CONFIGURATOR GOES HERE
+
+      <input type="hidden" value="QUERY_PARAM['template']" />
+
+      <amp-iframe width="300" height="500"
+        sandbox="allow-scripts"
+        layout="responsive"
+        frameborder="0"
+        src="../configurator/index.html?QUERY_PARAM(template)"
+        data-amp-replace="QUERY_PARAM">
+        <amp-img layout="fill" src="https://www.ampproject.org/static/img/home/home_icon_performance.svg" placeholder></amp-img>
+      </amp-iframe>
+      </iframe>
     </article>
     <aside class="col-2 xs-hide"></aside>
   </main>

--- a/www/configurator.html
+++ b/www/configurator.html
@@ -1,0 +1,40 @@
+{{!
+<!---
+Copyright 2017 The AMP Start Authors. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS-IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+}}
+
+<!doctype html>
+{{#www-howitworks}}
+<html ⚡>
+  {{> ../utils/amp-page-head.snip.html}}
+<body>
+  {{> ../components/navbar/navbar.snip.html}}
+  <header class="www-header">
+    <h1 class="mb4 px2 col-12 sm-col-8 mx-auto">Configurator</h1>
+    <span class="h3 block mb4 px2 col-12 sm-col-8 mx-auto"></span>
+  </header>
+  <main class="www-howitworks flex px2">
+    <aside class="col-2 xs-hide"></aside>
+    <article class="flex-auto col-8">
+      CONFIGURATOR GOES HERE
+    </article>
+    <aside class="col-2 xs-hide"></aside>
+  </main>
+  {{> ../components/footer/footer.snip.html}}
+  {{> ../utils/www-analytics.snip.html}}
+</body>
+</html>
+{{/www-howitworks}}

--- a/www/configurator.html
+++ b/www/configurator.html
@@ -37,7 +37,6 @@ limitations under the License.
         src="../configurator/index.html?template=article#--h1=16rem&--h2=18rem">
         <amp-img layout="fill" src="https://www.ampproject.org/static/img/home/home_icon_performance.svg" placeholder></amp-img>
       </amp-iframe>
-      </iframe>
     </article>
     <aside class="col-2 xs-hide"></aside>
   </main>

--- a/www/configurator.html
+++ b/www/configurator.html
@@ -29,16 +29,12 @@ limitations under the License.
   <main class="www-howitworks flex px2">
     <aside class="col-2 xs-hide"></aside>
     <article class="flex-auto col-8">
-      CONFIGURATOR GOES HERE
-
-      <input type="hidden" value="QUERY_PARAM['template']" />
-
-      <amp-iframe width="300" height="500"
+      <amp-iframe width="206" height="366"
+        class="configurator__iframe"
         sandbox="allow-scripts"
         layout="responsive"
         frameborder="0"
-        src="../configurator/index.html?QUERY_PARAM(template)"
-        data-amp-replace="QUERY_PARAM">
+        src="../configurator/index.html?template=article#--h1=16rem&--h2=18rem">
         <amp-img layout="fill" src="https://www.ampproject.org/static/img/home/home_icon_performance.svg" placeholder></amp-img>
       </amp-iframe>
       </iframe>

--- a/www/configurator.json
+++ b/www/configurator.json
@@ -1,0 +1,83 @@
+{
+  "www-howitworks": {
+    "head-tag": {
+      "title": "AMP Start - Configurator",
+      "canonical-path": "configurator",
+      "extensions": [
+        "amp-sidebar",
+        "amp-analytics"
+      ],
+      "css-path": "www/configurator/page.css",
+      "font-stylesheets": [
+        "https://fonts.googleapis.com/css?family=Inconsolata|Montserrat"
+      ],
+      "favicon": {
+        "href": "../img/www/amp_favicon.png"
+      }
+    },
+    "navbar": {
+      "logo": {
+        "url": "../img/www/amp_start_logo.svg",
+        "alt": "AMP start home logo",
+        "width": "119",
+        "height": "26",
+        "classes": "xs-hide sm-hide",
+        "href": "/"
+      },
+      "name": "The Blog",
+      "sidebar-id": "header-sidebar",
+      "nav": [
+        {
+          "link": {"url": "index.html#templates", "text": "Templates"}
+        },
+        {
+          "link": {"url": "components.html", "text": "Components"}
+        },
+        {
+          "link": {"url": "getstarted.html", "text": "Get Started"}
+        },
+        {
+          "link": {"url": "howitworks.html", "text": "How it works"}
+        },
+        {
+          "link": {"url": "https://www.ampproject.org/learn/about-amp/", "text": "What is AMP?", "target": "_blank"}
+        },
+        {
+          "link": {"url": "https://github.com/ampproject/ampstart", "text": "GitHub", "target": "_blank"}
+        }
+      ],
+      "social-follow": {
+        "links": [
+          {"twitter": "https://twitter.com/AMPhtml"},
+          {"github": "https://github.com/ampproject/ampstart"},
+          {"slack": "https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877"},
+          {"wordpress": "https://amphtml.wordpress.com"}
+        ]
+      }
+    },
+    "footer": {
+      "social-follow": {
+        "links": [
+          {"twitter": "https://twitter.com/AMPhtml"},
+          {"github": "https://github.com/ampproject/ampstart"},
+          {"slack": "https://docs.google.com/forms/d/1wAE8w3K5preZnBkRk-MD1QkX8FmlRDxd_vs4bFSeJlQ/viewform?fbzx=4406980310789882877"},
+          {"wordpress": "https://amphtml.wordpress.com"}
+        ]
+      },
+      "faq-links": {
+        "links": [
+          {"text": "Privacy", "url": "https://www.google.com/policies/privacy/", "target": "_blank"},
+          {"text": "License", "url": "https://github.com/ampproject/ampstart/blob/master/LICENSE", "target": "_blank"}
+        ]
+      },
+      "copyright": {
+        "text": "AMP Start is part of the Accelerated Mobile Pages Project"
+      }
+    },
+    "notification": {
+      "id": "ast-cookie-notif",
+      "text": "This site uses cookies to collect statistics and improve user experience. By continuing to use this site you are agreeing to our use of cookies.",
+      "action-text": "Accept"
+    }
+  }
+}

--- a/www/configurator.json
+++ b/www/configurator.json
@@ -5,6 +5,7 @@
       "canonical-path": "configurator",
       "extensions": [
         "amp-sidebar",
+        "amp-iframe",
         "amp-analytics"
       ],
       "css-path": "www/configurator/page.css",

--- a/www/configurator/src/index.css
+++ b/www/configurator/src/index.css
@@ -14,10 +14,20 @@
  * limitations under the License.
  */
 
-body {
+html, body {
   background-color: lightgrey;
+  margin: 0px;
+  height: 100%;
+  width: 100%;
 }
 
 #root {
-  height: 500px;
+  height: 100%;
+  width: 100%;
+}
+
+iframe {
+  width: 100%;
+  height: 100%;
+  border-width: 0px;
 }

--- a/www/configurator/src/index.html
+++ b/www/configurator/src/index.html
@@ -28,25 +28,7 @@
     <!--[if lt IE 10]>
       <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
     <![endif]-->
-
-    <div>
-      <h1>Amp Start Configurator test</h1>
-      <pre>
-        Plase add "template=article" in the url search params, and reload the page.
-        Example:
-        <a href="http://localhost:8080/?template=article">http://localhost:8080/?template=article</a>
-
-        Variables can be added in the url hash params.
-        Examples:
-        <a href="http://localhost:8080/?template=article#--h1=16rem&--h2=18rem">http://localhost:8080/?template=article#--h1=16rem&--h2=18rem</a>
-        <a href="http://localhost:8080/?template=article#--h1=1rem&--h2=2rem">http://localhost:8080/?template=article#--h1=1rem&--h2=2rem</a>
-        <a href="http://localhost:8080/?template=article#--h1=4rem&--h2=9rem">http://localhost:8080/?template=article#--h1=4rem&--h2=9rem</a>
-      </pre>
-      <form>
-      </form>
-
-      <div id="root">
-      </div>
+    <div id="root">
     </div>
   </body>
 </html>

--- a/www/configurator/src/index.js
+++ b/www/configurator/src/index.js
@@ -54,12 +54,17 @@ function getUrlCssVars() {
 const configuratorInit = [];
 const templateCssPath = `${cssPath}${getUrlTemplate()}/page`;
 configuratorInit.push(
-  fetch(`${templateCssPath}.json`).then(response => {
+
+  fetch(new Request(`${templateCssPath}.json`, {
+    mode: 'no-cors'
+  })).then(response => {
     return response.json();
   })
 );
 configuratorInit.push(
-  fetch(`${templateCssPath}.css`).then(response => {
+  fetch(new Request(`${templateCssPath}.css`, {
+    mode: 'no-cors'
+  })).then(response => {
     return response.text();
   })
 );


### PR DESCRIPTION
**Do Not Pull**

Since today is my last day in the office, making this PR, as I started a container to display the live reloading configurator. So this is the code I had written for it, and couldn't get past trying to get URL Params in the iframe, as they are not allowed.

Still needs to be done:

[  ] Write some invalid `<script>` tags to grab the template from the configurator url.
[  ] Place the configurator URL in the iframe.
[  ] Use the template page.css json to create an `amp-list`.
[  ] Use amp-bind to bind the template variables to the configurator iframe.
[  ]  Style the inner configurator iframe to be the same width and height as the outer iframe.

# Example

<img width="1680" alt="screen shot 2017-08-18 at 11 08 14 am" src="https://user-images.githubusercontent.com/1448289/29471627-905053b8-8405-11e7-8d8b-d36972b67e54.png">
