### PR TITLE
[GALLERY] Only validate .amp.html files

### DIFF
--- a/tasks/validate.js
+++ b/tasks/validate.js
@@ -20,7 +20,7 @@ const config = require('./config');
 
 function validate() {
   return gulp.src([
-        `${config.dest.templates}/**/*.html`,
+        `${config.dest.templates}/**/*amp.html`,
         `!${config.dest.hl_partials}/**/*.html`,
         `!${config.dest.configurator}/**/*.html`,
       ])


### PR DESCRIPTION
This allows non-AMP HTML files to be used, in order to load them via an iframe. This is necessary for the next PR for the Gallery to pass the build.

Related to #576