### PR TITLE
[LAND-SEE] - Refactor CSS to better reflect ampstart typography standards

### DIFF
--- a/css/CSS_SIZES.md
+++ b/css/CSS_SIZES.md
@@ -6,7 +6,7 @@
 | templates/blog/page.css       | 24114                | 24.11 KB |
 | templates/e-commerce/page.css | 41579                | 41.58 KB |
 | templates/gallery/page.css    | 33038                | 33.04 KB |
-| templates/land-see/page.css   | 43094                | 43.09 KB |
+| templates/land-see/page.css   | 43272                | 43.27 KB |
 | templates/lune/page.css       | 47161                | 47.16 KB |
 | templates/test/page.css       | 23957                | 23.96 KB |
 | templates/themes_1/page.css   | 25525                | 25.52 KB |

--- a/css/CSS_SIZES.md
+++ b/css/CSS_SIZES.md
@@ -12,7 +12,7 @@
 | templates/themes_1/page.css   | 25525                | 25.52 KB |
 | templates/themes_2/page.css   | 24446                | 24.45 KB |
 | templates/thescenic/page.css  | 23965                | 23.96 KB |
-| templates/travel/page.css     | 14709                | 14.71 KB |
+| templates/travel/page.css     | 20757                | 20.76 KB |
 | www/components/page.css       | 22903                | 22.90 KB |
 | www/getstarted/page.css       | 18573                | 18.57 KB |
 | www/howitworks/page.css       | 18573                | 18.57 KB |

--- a/css/templates/land-see/page.css
+++ b/css/templates/land-see/page.css
@@ -49,6 +49,42 @@ h4,
   line-height: var(--line-height-2);
 }
 
+.ampstart-title-lg {
+  font-size: var(--h0);
+  line-height: var(--line-height-1);
+  letter-spacing: normal;
+}
+
+.ampstart-title-md {
+  font-size: var(--h1);
+  line-height: var(--line-height-4);
+  letter-spacing: normal;
+}
+
+.ampstart-title-sm {
+  font-size: var(--h4);
+  line-height: var(--line-height-1);
+  letter-spacing: .2px;
+}
+
+.ampstart-subtitle {
+  color: var(--color-font-primary);
+  font-size: var(--h5);
+  line-height: var(--line-height-1);
+  letter-spacing: normal;
+}
+
+.ampstart-caption {
+  font: 400 var(--h6)/var(--line-height-2) var(--font-primary);
+  letter-spacing: normal;
+}
+
+.land-see-page-navigation,
+.land-see-page-navigation h3,
+.land-see-page-navigation button {
+  font: 400 var(--h7)/var(--line-height-4) var(--font-navigation);
+}
+
 .land-see-section-header {
   font: 600 var(--h7)/var(--line-height-3) var(--font-navigation);
   color: var(--color-font-primary);
@@ -112,11 +148,10 @@ h4,
 
 .land-see-sidebar-nav-item {
   font-family: var(--font-secondary);
-  font-size: var(--h4);
-  font-weight: bold;
+  color: var(--color-font-primary);
   text-transform: capitalize;
   letter-spacing: .6px;
-  color: var(--color-font-primary);
+  line-height: var(--line-height-4);
 }
 
 .ampstart-dropdown-item {
@@ -460,23 +495,22 @@ h4,
   }
 }
 
+.land-see-post-title {
+  font-weight: 600;
+}
+
 .land-see a.land-see-post-category {
-  font: 400 var(--h7)/var(--line-height-4) var(--font-navigation);
   color: var(--color-font-accent);
   letter-spacing: 1.4px;
 }
 
 .land-see-post-item h4 {
-  font: 600 var(--h4)/var(--line-height-1) var(--font-secondary);
+  font-family: var(--font-secondary);
   color: var(--color-font-primary);
 }
 
 .land-see-post-item h4 a:hover {
   opacity: .77;
-}
-
-.land-see-post-item p {
-  font: 400 var(--h6)/var(--line-height-2) var(--font-primary);
 }
 
 /* Instagram/Sale CTAs */
@@ -626,13 +660,14 @@ h4,
 }
 
 .land-see-hero-title {
-  font: 400 var(--h1)/var(--line-height-1) var(--font-primary);
-  letter-spacing: normal;
+  line-height: var(--line-height-1);
+  font-family: var(--font-primary);
 }
 
 .land-see-hero-caption {
   width: 28rem;
-  font: 400 var(--h7)/var(--line-height-1) var(--font-primary);
+  font-size: var(--h7);
+  line-height: var(--line-height-1);
   opacity: .7;
 }
 
@@ -699,7 +734,8 @@ h4,
   }
 
   .land-see-hero-title {
-    font: 600 var(--h0)/var(--line-height-1) var(--font-primary);
+    font-weight: 600;
+    font-size: var(--h0);
   }
 
   .land-see-hero-caption {
@@ -737,7 +773,7 @@ h4,
 /********** Stories Template **********/
 
 .land-see-category h1 {
-  font: 500 var(--h1)/var(--line-height-4) var(--font-primary);
+  font-family: var(--font-primary);
   color: var(--color-font-primary);
 }
 
@@ -776,7 +812,6 @@ h4,
 
 .land-see-next-page,
 .land-see-prev-page {
-  font: 400 var(--h7)/var(--line-height-4) var(--font-navigation);
   color: var(--color-font-accent);
   letter-spacing: 1.4px;
   border: none;
@@ -882,22 +917,20 @@ h4,
   text-align: center;
 }
 
-.land-see-story-detail .land-see-hero-title {
-  font: 600 var(--h0)/var(--line-height-1) var(--font-primary);
-}
-
 .land-see-story-detail .land-see-hero-title,
-.land-see-story-detail .land-see-hero-caption,
-.land-see-story-subheader {
+.land-see-story-detail .land-see-hero-caption {
   color: var(--color-font-primary);
 }
 
 .land-see-story-detail .land-see-hero-caption {
+  font-size: var(--h6);
+  line-height: var(--line-height-2);
   width: auto;
 }
 
-.land-see-story-subheader {
-  font: 600 var(--h5)/var(--line-height-1) var(--font-secondary);
+.land-see-story-subtitle {
+  font-family: var(--font-secondary);
+  font-weight: 600;
   margin-bottom: -0.5rem;
 }
 
@@ -961,7 +994,6 @@ h4,
 
 .land-see-story-social-share-heading {
   float: left;
-  font: 400 var(--h7)/var(--line-height-4) var(--font-navigation);
   color: var(--color-font-accent);
   text-transform: uppercase;
   padding-top: .5rem;

--- a/templates/land-see/data.json
+++ b/templates/land-see/data.json
@@ -33,7 +33,7 @@
     },
     "nav": [
       {
-        "link": {"url": "stories.amp.html", "nav-item-classes": "land-see-sidebar-nav-item", "text": "Stories"},
+        "link": {"url": "stories.amp.html", "nav-item-classes": "land-see-sidebar-nav-item ampstart-title-sm bold", "text": "Stories"},
         "dropdown": {
           "initial-state": "expanded",
           "heading": "Stories",
@@ -60,13 +60,13 @@
         }
       },
       {
-        "link": {"url": "#", "nav-item-classes": "land-see-sidebar-nav-item", "text": "Shop"}
+        "link": {"url": "#", "nav-item-classes": "land-see-sidebar-nav-item ampstart-title-sm bold", "text": "Shop"}
       },
       {
-        "link": {"url": "#", "nav-item-classes": "land-see-sidebar-nav-item", "text": "About"}
+        "link": {"url": "#", "nav-item-classes": "land-see-sidebar-nav-item ampstart-title-sm bold", "text": "About"}
       },
       {
-        "link": {"url": "#", "nav-item-classes": "land-see-sidebar-nav-item", "text": "Contact"}
+        "link": {"url": "#", "nav-item-classes": "land-see-sidebar-nav-item ampstart-title-sm bold", "text": "Contact"}
       }
     ],
     "social-follow": {

--- a/templates/land-see/kim-myeong.amp.html
+++ b/templates/land-see/kim-myeong.amp.html
@@ -59,18 +59,18 @@ limitations under the License.
     <section class="land-see-story-detail relative mx-auto mb4 pt2">
       {{#land-see-post-detail}}
       <div class="mx-auto center {{post-classes}}">
-        <a class="land-see-post-category underline caps max-width-1 pb1" href="{{post-category-url}}">{{post-category}}</a>
-        <h1 class="land-see-hero-title pt2 mx2"><a class="text-decoration-none" href="{{post-url}}">{{{post-title}}}</a></h1>
-        <p class="land-see-hero-caption mx-auto max-width-2 pt1 px2 mb3">
+        <a class="land-see-post-category land-see-page-navigation underline caps max-width-1 pb1" href="{{post-category-url}}">{{post-category}}</a>
+        <h1 class="land-see-hero-title ampstart-title-lg bold pt2 mx2"><a class="text-decoration-none" href="{{post-url}}">{{{post-title}}}</a></h1>
+        <p class="land-see-hero-caption ampstart-caption mx-auto max-width-2 pt1 px2 mb3">
           {{{post-copy}}}
         </p>
       </div>
       {{/land-see-post-detail}}
 
       {{#land-see-copy}}
-        {{#subheader}}
-        <h2 class="land-see-story-subheader max-width-3 mx-auto pb0 pt4 px4">{{.}}</h2>
-        {{/subheader}}
+        {{#subtitle}}
+        <h2 class="land-see-story-subtitle ampstart-subtitle bold max-width-3 mx-auto pb0 pt4 px4">{{.}}</h2>
+        {{/subtitle}}
         {{#paragraph}}
         <p class="land-see-story-copy max-width-3 mx-auto py2 px4">
           {{{.}}}
@@ -173,7 +173,7 @@ limitations under the License.
 
     {{#land-see-story-nav}}
     <section class="land-see-story-nav mx-auto center px1 relative z2">
-      <div class="land-see-paging mb4 flex flex-wrap clearfix">
+      <div class="land-see-paging land-see-page-navigation mb4 flex flex-wrap clearfix">
         <div class="sm-col sm-col-3 col-6 left-align"><a href="{{previous-url}}" class="land-see-prev-page mt2 ml2 inline-block relative">Previous Story</a></div>
         <div class="land-see-story-social flex flex-auto align-top pt1 justify-center">
             {{> ../../components/social-follow/social-follow.snip.html}}

--- a/templates/land-see/kim-myeong.amp.json
+++ b/templates/land-see/kim-myeong.amp.json
@@ -18,7 +18,7 @@
     },
     "land-see-copy": [
       {
-        "subheader": "What makes Kim different?"
+        "subtitle": "What makes Kim different?"
       },
       {
         "paragraph": "<b>Sed porta ultrices eros, a lobortis lectus elementum at.</b> Nullam lobortis sit amet metus vel consequat. Vivamus varius quis ipsum eget ullamcorper. Praesent ultricies massa condimentum sem fermentum pulvinar vitae dignissim lectus. Sed suscipit convallis erat, vel ultricies ipsum euismod sed. Donec vitae vestibulum justo. In tristique vitae dolor sed vulputate. Praesent sed risus vel felis ullamcorper iaculis. Donec vel lacinia enim, vel laoreet dolor. Etiam pharetra blandit felis eget bibendum."

--- a/templates/land-see/land-see.amp.html
+++ b/templates/land-see/land-see.amp.html
@@ -166,9 +166,9 @@ limitations under the License.
             </amp-img>
             {{/image}}
             <div class="land-see-hero-typography mx-auto center z2 {{post-classes}}">
-              <a class="land-see-post-category underline caps max-width-1 sm-hide md-hide lg-hide" href="{{post-category-url}}">{{post-category}}</a>
-              <h1 class="land-see-hero-title"><a class="text-decoration-none" href="{{post-url}}">{{{post-title}}}</a></h1>
-              <p class="land-see-hero-caption mx-auto max-width-2 pt1 mb3">
+              <a class="land-see-post-category land-see-page-navigation underline caps max-width-1 sm-hide md-hide lg-hide" href="{{post-category-url}}">{{post-category}}</a>
+              <h1 class="land-see-hero-title ampstart-title-md"><a class="text-decoration-none" href="{{post-url}}">{{{post-title}}}</a></h1>
+              <p class="land-see-hero-caption ampstart-caption mx-auto max-width-2 pt1 mb3">
                 {{{post-copy}}}
               </p>
               <a class="land-see-hero-button text-decoration-none relative" href="{{post-url}}">Read More</a>
@@ -253,9 +253,9 @@ limitations under the License.
                 </amp-img>
               {{/image}}
             </a>
-            <a class="land-see-post-category inline-block pt1 underline caps" href="{{post-category-url}}">{{post-category}}</a>
-            <h4 class="pt1"><a class="text-decoration-none" href="{{post-url}}">{{post-title}}</a></h4>
-            <p class="pt1 pb3">{{post-copy}}</p>
+            <a class="land-see-post-category land-see-page-navigation inline-block pt1 underline caps" href="{{post-category-url}}">{{post-category}}</a>
+            <h4 class="land-see-post-title ampstart-title-sm pt1"><a class="text-decoration-none" href="{{post-url}}">{{post-title}}</a></h4>
+            <p class="ampstart-caption pt1 pb3">{{post-copy}}</p>
           </li>
           {{/recent-stories}}
         </ul>

--- a/templates/land-see/partials/story-carousel.snip.html
+++ b/templates/land-see/partials/story-carousel.snip.html
@@ -50,9 +50,9 @@ limitations under the License.
                   </amp-img>
                 <%/image%>
               </a>
-              <a class="land-see-post-category inline-block pt1 underline caps" href="<%post-category-url%>"><%post-category%></a>
-              <h4 class="pt1"><a class="text-decoration-none" href="<%post-url%>"><%post-title%></a></h4>
-              <p class="pt1 pb3"><%post-copy%></p>
+              <a class="land-see-post-category land-see-page-navigation inline-block pt1 underline caps" href="<%post-category-url%>"><%post-category%></a>
+              <h4 class="land-see-post-title ampstart-title-sm pt1"><a class="text-decoration-none" href="<%post-url%>"><%post-title%></a></h4>
+              <p class="ampstart-caption pt1 pb3"><%post-copy%></p>
             </div>
             <%/story-post%>
           </div>

--- a/templates/land-see/partials/story-categories.snip.html
+++ b/templates/land-see/partials/story-categories.snip.html
@@ -44,9 +44,9 @@ limitations under the License.
                     </amp-img>
                   <%/image%>
                 </a>
-                <a class="land-see-post-category inline-block pt1 underline caps" href="<%post-category-url%>"><%post-category%></a>
-                <h4 class="pt1"><a class="text-decoration-none" href="<%post-url%>"><%post-title%></a></h4>
-                <p class="pt1 pb3"><%post-copy%></p>
+                <a class="land-see-post-category land-see-page-navigation inline-block pt1 underline caps" href="<%post-category-url%>"><%post-category%></a>
+                <h4 class="land-see-post-title ampstart-title-sm pt1"><a class="text-decoration-none" href="<%post-url%>"><%post-title%></a></h4>
+                <p class="ampstart-caption pt1 pb3"><%post-copy%></p>
               </li>
               <%/land-see-category%>
             </ul>

--- a/templates/land-see/stories.amp.html
+++ b/templates/land-see/stories.amp.html
@@ -103,7 +103,7 @@ limitations under the License.
 
     {{#stories-category}}
     <section class="land-see-category land-see-recent-content relative mx-auto mb2">
-      <h1 class="center pt1">Stories</h1>
+      <h1 class="ampstart-title-md center pt1">Stories</h1>
       <div [class]="selectedContainerClass" class="land-see-categories-nav-page-load center mb2 mx1 fit relative fit">
         <div class="land-see-categories-inner-nav nowrap">
           {{#category}}
@@ -180,17 +180,17 @@ limitations under the License.
                   data-videoid="<%videoid%>">
                 </amp-youtube>
                 <%/youtube%>
-                <a class="land-see-post-category inline-block pt1 underline caps" href="<%post-category-url%>"><%post-category%></a>
-                <h4 class="pt1"><a class="text-decoration-none" href="<%post-url%>"><%post-title%></a></h4>
+                <a class="land-see-post-category land-see-page-navigation inline-block pt1 underline caps" href="<%post-category-url%>"><%post-category%></a>
+                <h4 class="land-see-post-title ampstart-title-sm pt1"><a class="text-decoration-none" href="<%post-url%>"><%post-title%></a></h4>
                 <%#post-copy%>
-                <p class="pt1 pb3"><%{post-copy}%></p>
+                <p class="ampstart-caption pt1 pb3"><%{post-copy}%></p>
                 <%/post-copy%>
               </li>
               <%/land-see-category%>
             </ul>
             <%#land-see-paging%>
             <div class="pt4 clearfix"></div>
-            <div class="land-see-paging mt4 mx2 fit <%classes%>">
+            <div class="land-see-paging land-see-page-navigation mt4 mx2 fit <%classes%>">
               <%#page-nav%>
               <button on="<%action%>" class="<%classes%>"><%button-text%></button>
               <%/page-nav%>


### PR DESCRIPTION
As recommended by @camelburrito in #685, I've cleaned up numerous `font:` declarations in the land-see styles and have overridden/implemented most of the classes found in `/ampstart-base/elements/typography.css`. Staging URL:

https://landseeampstart.firebaseapp.com/templates/land-see/stories.amp.html