### PR TITLE
[TRAVEL] Remove unused CSS component

### DIFF
--- a/css/templates/travel/travel-results.css
+++ b/css/templates/travel/travel-results.css
@@ -48,7 +48,6 @@
 @import 'components/_filter-bar';
 @import 'components/_filter-overlay';
 @import 'components/_filters';
-@import 'components/_hero';
 @import 'components/_icon';
 @import 'components/_like';
 @import 'components/_popular';


### PR DESCRIPTION
Removes an unused CSS component in hopes of reducing the `travel-results` CSS filesize.