### PR TITLE
[TRAVEL] Render initial Travel results

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -13,13 +13,17 @@ const travelData = JSON.parse(fs.readFileSync(src, 'utf8'));
  * sharing HTTP header on our response.
  *
  * @param {Object} req - The HTTP request object.
- * @param {Object} res - The HTTP resonse object.
+ * @param {Object} res - The HTTP response object.
  * @param {Function} next - The next HTTP handler to execute.
  */
 function cors(req, res, next) {
+  const port = process.env.NODE_ENV === 'production'
+    ? null
+    : new url.URL(req.query.__amp_source_origin).port;
+
   const host = process.env.NODE_ENV === 'production'
     ? `https://${req.hostname}`
-    : `http://${req.hostname}:5000`
+    : `http://${req.hostname}:${port}`;
 
   res.header('amp-access-control-allow-source-origin', host);
 
@@ -295,7 +299,7 @@ exports.search = functions.https.onRequest((req, res) => {
 /**
  * getSVGGraphPath data converts an array of numbers to valid SVG graph path
  * data.
- * 
+ *
  * @param {Array} data - The data to convert to SVG graph path format.
  * @param {Integer} width - The width of the SVG.
  * @param {Integer} height - The height of the SVG.

--- a/templates/travel/partials/footer/footer.snip.html
+++ b/templates/travel/partials/footer/footer.snip.html
@@ -55,7 +55,7 @@ limitations under the License.
               class="travel-input travel-input-big block col-12 flex-auto rounded-left"
               type="text"
               name="email"
-              placeholder="Enter your email address..."
+              placeholder="Enter your email"
             >
             <span class="travel-input-group-sep travel-border-gray relative z1 block"></span>
             <button

--- a/templates/travel/partials/util/amp-list-props.snip.html
+++ b/templates/travel/partials/util/amp-list-props.snip.html
@@ -20,7 +20,7 @@ limitations under the License.
 <!--
   The API interaction would ideally be handled with a form tag, instead of
   numerouse amp-list elements, unfortunately there is now way to render
-  form response data outside of the `form > div[sumbit-success]` element.
+  form response data outside of the `form > div[submit-success]` element.
 
   For now the app interactivity is provided by using a [src] bound amp-list
   element element in each location of the page the displays dynamic response
@@ -32,7 +32,7 @@ limitations under the License.
 -->
 }}
 
-src="/api/search?maxPrice=0{{!departure=&return=}}&query=&sort=popularity-desc"
+src="/api/search?maxPrice=800{{!departure=&return=}}&query=&sort=popularity-desc"
 [src]="
   '/api/search?maxPrice=' + (query_maxPrice < 801 ? query_maxPrice : 0) +
   {{!'&departure=' + query_departure +}}


### PR DESCRIPTION
Fixes #753

Fixes the issue where we weren't sending anything on the initial render of the Travel page.

Also updates the copy in the email field to be shorter, which prevents it from getting cut off.

cc @camelburrito @ericlindley-g 