### PR TITLE
Added <amp-consent> stuff for GDPR

### DIFF
--- a/components/consent/consent.css
+++ b/components/consent/consent.css
@@ -1,0 +1,101 @@
+@keyframes slideUp {
+  0% {
+    transform: translateY(100%);
+    opacity: 0.5;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+amp-consent {
+  background: white;
+  box-shadow: rgba(0, 0, 0, 0.26) 0 0 19px 0;
+  animation: .5s ease-out 0s 1 slideUp;
+}
+
+.consent-popup a {
+  text-transform: none;
+  font-size: inherit;
+  text-decoration: none;
+}
+
+.consent-popup a.close-button {
+  position: absolute;
+  color: #333;
+}
+
+.consent-popup .ampstart-btn {
+  width: 150px;
+  text-align: center;
+}
+
+.consent-popup p {
+  line-height: 20px;
+  font-size: 14px;
+}
+
+.consent-popup p a {
+  color: #b60845;
+}
+
+.consent-popup div {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.consent-popup button {
+  padding: 13px 18px;
+  width: 142px;
+  flex: none;
+  align-self: center;
+}
+
+/* phones */
+@media (max-width: 640px) {
+  amp-consent a.close-button {
+    font-size: 22px;
+    top: 15px;
+    right: 13px;
+  }
+  
+  .consent-popup div {
+    flex-flow: column wrap;
+    align-items: center;
+    margin: 12px 25px 15px 12px;
+  }
+
+  .consent-popup p {
+    padding: 5px 20px 5px 10px;
+    margin: 0 0 10px 0;
+  }
+}
+
+/* tablets and desktop */
+@media (min-width: 641px) {
+ .consent-popup a.close-button {
+    font-size: 25px;
+    left: 30px;
+  }
+
+  .consent-popup div {
+    flex-flow: row;
+    height: 100px;
+    margin: 0 40px;
+  }
+
+  .consent-popup p {
+    max-width: 660px;
+    padding: 0 25px 0 40px;
+    margin: 0;
+  }
+}
+
+@media (max-width: 320px) {
+  .consent-popup p {
+    line-height: 16px;
+    font-size: 12px;
+  }
+}

--- a/components/consent/consent.snip.html
+++ b/components/consent/consent.snip.html
@@ -1,0 +1,32 @@
+<amp-geo layout="nodisplay">
+  <script type="application/json">
+    {
+      "ISOCountryGroups": {
+        "eu": ["at", "be", "bg", "ch", "cy", "cz", "dk", "de", "ee", "el", "es", "fi", "fr", "hr", "ie", "is", "it", "li", "lv", "lt", "lu", "hu", "mt", "nl", "no", "pl", "pt", "ro", "si", "sk", "se", "uk"]
+      }
+    }
+  </script>
+</amp-geo> <!-- TODO: remove "us" -->
+
+<amp-consent id="consent" layout="nodisplay">
+  <script type="application/json">
+    {
+      "consents": {
+        "eu": {
+          "promptIfUnknownForGeoGroup": "eu",
+          "promptUI": "consent-popup"
+        }
+      }
+    }
+  </script>
+
+  <div id="consent-popup" class="consent-popup">
+    <div>
+      <a href="#" on="tap:consent.dismiss" class="close-button" role="button" tabindex="0">✕</a>
+      <p>
+        We use cookies to understand how you use our site and to improve your experience. By continuing to use our site, you accept our <a href="https://policies.google.com/technologies/cookies">use of cookies</a> and <a href="https://policies.google.com/privacy">privacy policy</a>.
+      </p>
+      <a class="ampstart-btn ampstart-btn-secondary caps text-decoration-none inline-block" on="tap:consent.accept" class="button text-label" role="button" tabindex="1">OK</a>
+    </div>
+  </div>
+</amp-consent>

--- a/css/www/shared.css
+++ b/css/www/shared.css
@@ -19,6 +19,7 @@
 @import '../../components/social-follow/social-follow';
 @import '../../components/footer/footer';
 @import '../../components/user-notification/user-notification';
+@import '../../components/consent/consent';
 @import 'page-vars';
 
 h1,h2,h3,h4,h5,h6,

--- a/utils/amp-page-head.snip.html
+++ b/utils/amp-page-head.snip.html
@@ -22,6 +22,7 @@ limitations under the License.
   <title>{{title}}</title>
   <link rel="canonical" href="https://www.ampstart.com/{{#canonical-path}}{{{canonical-path}}}{{/canonical-path}}">
   <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1">
+  <meta name="amp-google-client-id-api" content="googleanalytics">
 
   <script async src="https://cdn.ampproject.org/v0.js"></script>
 

--- a/www/components.html
+++ b/www/components.html
@@ -92,6 +92,7 @@ limitations under the License.
   </main>
   </amp-selector>
   {{> partials/components/footer.snip.html}}
+  {{> ../components/consent/consent.snip.html}}
   {{> ../utils/www-analytics.snip.html}}
 </body>
 </html>

--- a/www/components.json
+++ b/www/components.json
@@ -8,6 +8,8 @@
         "amp-iframe",
         "amp-selector",
         "amp-analytics",
+        "amp-geo",
+        "amp-consent",
         "amp-accordion"
       ],
       "css-path": "www/components/page.css",

--- a/www/getstarted.html
+++ b/www/getstarted.html
@@ -79,6 +79,7 @@ limitations under the License.
     <aside class="col-2 xs-hide"></aside>
   </main>
   {{> partials/components/footer.snip.html}}
+  {{> ../components/consent/consent.snip.html}}
   {{> ../utils/www-analytics.snip.html}}
 </body>
 </html>

--- a/www/getstarted.json
+++ b/www/getstarted.json
@@ -6,7 +6,9 @@
       "extensions": [
         "amp-carousel",
         "amp-sidebar",
-        "amp-analytics"
+        "amp-analytics",
+        "amp-geo",
+        "amp-consent"
       ],
       "css-path": "www/howitworks/page.css",
       "font-stylesheets": [

--- a/www/howitworks.html
+++ b/www/howitworks.html
@@ -78,6 +78,7 @@ limitations under the License.
     <aside class="col-2 xs-hide"></aside>
   </main>
   {{> partials/components/footer.snip.html}}
+  {{> ../components/consent/consent.snip.html}}
   {{> ../utils/www-analytics.snip.html}}
 </body>
 </html>

--- a/www/howitworks.json
+++ b/www/howitworks.json
@@ -5,7 +5,9 @@
       "canonical-path": "howitworks",
       "extensions": [
         "amp-sidebar",
-        "amp-analytics"
+        "amp-analytics",
+        "amp-geo",
+        "amp-consent"
       ],
       "css-path": "www/howitworks/page.css",
       "font-stylesheets": [

--- a/www/index.html
+++ b/www/index.html
@@ -151,6 +151,7 @@ limitations under the License.
     </section>
     {{/help-section}}
   </main>
+  {{> ../components/consent/consent.snip.html}}
   {{> partials/components/footer.snip.html}}
   {{#features-showcase}}
   {{#feature}}

--- a/www/index.json
+++ b/www/index.json
@@ -8,7 +8,9 @@
         "amp-lightbox",
         "amp-iframe",
         "amp-selector",
-        "amp-analytics"
+        "amp-analytics",
+        "amp-geo",
+        "amp-consent"
       ],
       "css-path": "www/index/page.css",
       "font-stylesheets": [

--- a/www/templates.html
+++ b/www/templates.html
@@ -104,6 +104,7 @@ limitations under the License.
   </main>
   </amp-selector>
   {{> partials/components/footer.snip.html}}
+  {{> ../components/consent/consent.snip.html}}
   {{> ../utils/www-analytics.snip.html}}
   {{#template-groups}}
   {{#template-group}}

--- a/www/templates.json
+++ b/www/templates.json
@@ -8,7 +8,9 @@
         "amp-lightbox",
         "amp-iframe",
         "amp-selector",
-        "amp-analytics"
+        "amp-analytics",
+        "amp-geo",
+        "amp-consent"
       ],
       "css-path": "www/templates/page.css",
       "font-stylesheets": [


### PR DESCRIPTION
I wasn't sure whether the `components` dir was the best place to stash the consent HTML and CSS. For example, www/partials contains other partials like `footer.snip.html`.  But I liked the idea of putting the HTML and CSS in the same dir.  Let me know if you want this moved elsewhere.