### PR TITLE
Combined #822 and #823 typo fixes into a single PR

### DIFF
--- a/components/related-article/related-article.snip.html
+++ b/components/related-article/related-article.snip.html
@@ -44,7 +44,7 @@ limitations under the License.
       </p>
     {{/content-text}}
     {{#article-link}}
-      <a href="{{{url}}}" class="ampstart-rekated-article-readmore block text-decoration-none ampstart-label">{{text}}</a>
+      <a href="{{{url}}}" class="ampstart-related-article-readmore block text-decoration-none ampstart-label">{{text}}</a>
     {{/article-link}}
   </article>
 </section>

--- a/hl-partials/related-article.html
+++ b/hl-partials/related-article.html
@@ -9,7 +9,7 @@
         amet fringilla magna ante sit amet magna. Praesent sem leo,
         fringilla at dolor eu, blandit malesuada dolor.
     </p>
-    <a href="#" class="ampstart-rekated-article-readmore block text-decoration-none ampstart-label">
+    <a href="#" class="ampstart-related-article-readmore block text-decoration-none ampstart-label">
       Read more
     </a>
   </article>


### PR DESCRIPTION
closes #822 
closes #823 

As requested by @camelburrito , this combines their simple typo fixes on the site for the related articles component, into a single PR

