### PR TITLE
Support bindings on non-AMP elements

### DIFF
--- a/lib/next-amp-demo/pages/components/AmpBind.tsx
+++ b/lib/next-amp-demo/pages/components/AmpBind.tsx
@@ -15,23 +15,31 @@
  */
 
 import React from 'react';
-import {AmpImg, AmpCarousel} from '@ampproject/toolbox-next-amp/src-gen';
+import {AmpBind, AmpImg, AmpCarousel} from '@ampproject/toolbox-next-amp';
 export const config = {amp: true};
 
 export default () => (
   <>
     <h1>amp-bind</h1>
+
+    <h2>Binding AMP Elements</h2>
     <AmpCarousel bindSlide='slide' width='400' height='300' type='slides'>
-      <AmpImg src='https://picsum.photos/id/231/400/300' layout='fill'></AmpImg>
-      <AmpImg src='https://picsum.photos/id/232/400/300' layout='fill'></AmpImg>
-      <AmpImg src='https://picsum.photos/id/233/400/300' layout='fill'></AmpImg>
+      <AmpImg src='https://picsum.photos/id/231/400/300' layout='fill' />
+      <AmpImg src='https://picsum.photos/id/232/400/300' layout='fill' />
+      <AmpImg src='https://picsum.photos/id/233/400/300' layout='fill' />
     </AmpCarousel>
     <button
       on='tap:AMP.setState({
-    slide: slide != undefined ? (slide + 1) % 3 : 0
-  })'
+        slide: slide != undefined ? (slide + 1) % 3 : 0
+      })'
     >
       Next slide
     </button>
+
+    <h2>Binding non-AMP Elements</h2>
+    <AmpBind bindText="greeting || '' ">
+      <div />
+    </AmpBind>
+    <button on="tap:AMP.setState({ greeting: 'hello world' })">Say hello</button>
   </>
 );

--- a/lib/next-amp-demo/test/out/components/AmpBind.out
+++ b/lib/next-amp-demo/test/out/components/AmpBind.out
@@ -11,13 +11,13 @@
     <script async src="https://cdn.ampproject.org/v0.js"></script>
     <script
       async
-      custom-element="amp-bind"
-      src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"
+      custom-element="amp-carousel"
+      src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"
     ></script>
     <script
       async
-      custom-element="amp-carousel"
-      src="https://cdn.ampproject.org/v0/amp-carousel-0.2.js"
+      custom-element="amp-bind"
+      src="https://cdn.ampproject.org/v0/amp-bind-0.1.js"
     ></script>
     <style amp-custom></style>
     <link rel="canonical" href="/components/AmpBind" />
@@ -25,6 +25,7 @@
   <body>
     <!-- __NEXT_DATA__ -->
     <h1>amp-bind</h1>
+    <h2>Binding AMP Elements</h2>
     <amp-carousel
       width="400"
       height="300"
@@ -55,6 +56,11 @@
       on="tap:AMP.setState({ slide: slide != undefined ? (slide + 1) % 3 : 0 })"
     >
       Next slide
+    </button>
+    <h2>Binding non-AMP Elements</h2>
+    <div data-amp-bind-text="greeting || '' "></div>
+    <button on="tap:AMP.setState({ greeting: 'hello world' })">
+      Say hello
     </button>
   </body>
 </html>

--- a/lib/next-amp/README.md
+++ b/lib/next-amp/README.md
@@ -215,14 +215,28 @@ Better than Option 1, but makes things more complicated.
 
 ### amp-bind
 
-For `amp-bind` expressions, the `amp-bind` extension is automatically imported using the same approach as for `amp-fx-collection`. The following will work out-of-the-box:
+AMP bindings can be expressed using the the `bindX` short-form instead of `data-amp-bind-x`. A nice
+side-effect is that most JS IDEs will offer component specific code-completion once you've
+typed `bind`.
+
+Here is an example binding an `AmpImg`'s `src` attribute via `bindSrc`:
 
 ```
-<div data-amp-bind-text="hello"/>
-<button on="tap:AMP.setState({ "hello": "world" })">
+<AmpImg width="300" height="200" src="image.png" bindSrc="imageUrl"/>
+<button on="tap:AMP.setState({ imageUrl: 'anotherImage.png' })">Change image</button>
 ```
 
-State can be initialized via:
+Unfortunately, this doesn't work for non-AMP tags such as `div` or `input`. In this case you need to
+wrap the element inside the `AmpBind` component:
+
+```
+<AmpBind bindText="greeting">
+  <div />
+</AmpBind>
+<button on="tap:AMP.setState({ greeting: 'hello world' })">Say hello</button>
+```
+
+`amp-state` can be initialized via:
 
 ```
 <AmpState id="myState">{{

--- a/lib/next-amp/build/generate.js
+++ b/lib/next-amp/build/generate.js
@@ -22,6 +22,7 @@ const loadAmp = require('./amp');
 const generateTypes = require('./generateTypes.js');
 const generateComponents = require('./generateComponents');
 const generateVersionMapping = require('./generateVersionMapping');
+const generateBindProps = require('./generateAmpBindProps');
 
 const prettierConfig = require('../../../prettier.config.js');
 
@@ -29,6 +30,7 @@ const config = {
   importHelper: 'AmpCustomElement.tsx',
   componentWrapper: 'index.tsx',
   versionMapping: 'versionMapping.ts',
+  bindProps: 'AmpBindProps.ts',
   typeDefinition: 'amp.d.tsx',
   dist: join(__dirname, '../src-gen/'),
   lincenseHeader: `/**
@@ -63,6 +65,9 @@ async function build() {
 
   const versionMapping = generateVersionMapping(config, amp);
   writeFile(config.versionMapping, versionMapping);
+
+  const bindProps = generateBindProps(config, amp);
+  writeFile(config.bindProps, bindProps);
 }
 
 function writeFile(name, content) {

--- a/lib/next-amp/build/generateAmpBindProps.js
+++ b/lib/next-amp/build/generateAmpBindProps.js
@@ -1,0 +1,15 @@
+module.exports = (config, amp) => {
+  const bindAttrs = Array.from(
+    new Set(amp.tags.map(tag => tag.bindAttrs.map(a => `${a.name}?: string`)).flat()).values()
+  );
+  return `${config.lincenseHeader}
+
+  import * as React from 'react';
+
+  type AmpBindProps = {
+    children: React.ReactElement;
+    ${bindAttrs.join(';\n')}
+  };
+  export default AmpBindProps;
+`;
+};

--- a/lib/next-amp/src/components/AmpBind.tsx
+++ b/lib/next-amp/src/components/AmpBind.tsx
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as React from 'react';
+import {AmpIncludeCustomElement} from '../../src-gen/';
+import AmpBindProps from '../../src-gen/AmpBindProps';
+
+/**
+ * Renders an amp-state element, by either adding local state via `value`
+ * or remote state via the `src` property.
+ */
+const AmpBind: React.FunctionComponent<AmpBindProps> = ({children, ...rest}) => {
+  const newProps = {};
+  Object.keys(rest).forEach(key => {
+    if (/^bind[A-Z]/g.test(key)) {
+      const newKey = `data-amp-bind-${key.substring(4).toLowerCase()}`;
+      newProps[newKey] = rest[key];
+    }
+  });
+  return (
+    <>
+      <AmpIncludeCustomElement name='amp-bind' />
+      {React.cloneElement(children, newProps)}
+    </>
+  );
+};
+
+export default AmpBind;


### PR DESCRIPTION
Going with a wrapper based approach for none AMP elements for now:

```
<AmpBind bindText="greeting">
  <div />
</AmpBind>
```

I don't see a different way to support the `bindX` shortcut for non-AMP
elements.